### PR TITLE
Fail loudly on tool errors and document the data_points LIKE pitfall (#3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — and publish shareable charts.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": { "name": "Defog" }
 }

--- a/SKILL.md
+++ b/SKILL.md
@@ -32,7 +32,8 @@ Shell working directory resets between calls — resolve the script's absolute
 path once (from this skill's directory) and use it in every invocation.
 
 Every subcommand prints JSON to stdout. Errors go to stderr with a non-zero
-exit code (2 = HTTP error, 3 = rate limit / quota).
+exit code (2 = HTTP error, 3 = rate limit / quota, 4 = server-reported tool
+error such as a SQL failure or statement timeout).
 
 ## Setup
 
@@ -79,8 +80,10 @@ in the environment first, then `api_key` in `~/.factiq/config.json`.
    deep-diving into one — for India check both `mospi` and `rbi`; for the US
    check `bls`, `bea`, `census`; energy means `eia`. Use `search` for
    obvious title matches and exploration SQL (`sql --explore`) for everything
-   else. `search` is substring matching, not semantic — exploration SQL on
-   the `series` and `dimensions` tables is the primary discovery tool. For
+   else. `search` is substring matching, not semantic — prefer short stems
+   (`rare`, not `rare earth`: BLS titles its rare-earth import price index
+   "precious, rare-earth, or radioactive"), and use exploration SQL on
+   the `series` and `dimensions` tables as the primary discovery tool. For
    multi-source stories, actually fetch data from 2+ schemas, don't just
    survey them.
 3. **Fetch in batches.** Once you know which series you need, issue all
@@ -122,13 +125,16 @@ series list to fetch the rest.
   the error says when it resets). Don't burn calls re-fetching data you have.
 - **403** — schema is admin-restricted for this account; drop it.
 - **SQL errors come back as HTTP 200** with an `{"error": "..."}` body
-  (syntax errors, timeouts, bad column names) — the CLI exits 0, so check
-  for an `error` key before trusting a result. Revise the query and rerun.
+  (syntax errors, timeouts, bad column names). The CLI surfaces these on
+  stderr with exit code 4 and never writes an `--out` file for them.
+  Revise the query and rerun.
 - **Zero rows** — your filter was too narrow. Broaden it yourself (see
   `references/sql-guide.md`). `--auto-retry` opts into a server-side LLM
   reviser, but you can usually revise better and cheaper yourself.
 - **SQL timeout** — statements are capped at 30s. Filter on indexed columns
-  (`series_id`, `dataset_code`) instead of scanning titles across the table.
+  (`series_id`, `dataset_code`) instead of scanning titles across the table,
+  and never pattern-match `series_id` on `data_points` — resolve ids from
+  `series` first (see the pitfall in `references/sql-guide.md`).
 
 ## References
 

--- a/references/schemas.md
+++ b/references/schemas.md
@@ -11,7 +11,7 @@ output (requests to them return 403).
 |---|---|---|
 | `bls` | Bureau of Labor Statistics | Employment (CES), unemployment (CPS, e.g. `LNS14000000`), CPI, PPI, JOLTS job openings, wages, productivity |
 | `oews` | BLS Occupational Employment & Wage Statistics | Wages and employment by occupation and metro area |
-| `census` | Census Bureau | International trade (incl. `us_census_hs` — monthly imports/exports by HS commodity and partner country), retail, housing, demographics |
+| `census` | Census Bureau | International trade (incl. `us_census_hs` — monthly imports/exports by HS commodity and partner country; quantity `_qty` series exist only at the 10-digit level, 6-digit lines are value-only), retail, housing, demographics |
 | `bea` | Bureau of Economic Analysis | GDP and components, personal income/spending, regional accounts |
 | `eia` | Energy Information Administration | Petroleum, natural gas, electricity, renewables — production, consumption, prices |
 | `ers` | USDA Economic Research Service | Agricultural and food economics |
@@ -23,7 +23,7 @@ output (requests to them return 403).
 | Schema | Source | Coverage |
 |---|---|---|
 | `china` | National Bureau of Statistics | Macro indicators: GDP, industrial production, fixed-asset investment, prices |
-| `china_customs` | General Administration of Customs (GACC) | Monthly imports/exports by 8-digit HS line and partner country (incl. rare earths) |
+| `china_customs` | General Administration of Customs (GACC) | Monthly imports/exports by 8-digit HS line and partner country (incl. rare earths). Data not yet loaded (listed under `schemas_without_data` in `context`) — for China–US trade use the `us_census_hs` mirror in `census` (US imports from China ≈ Chinese exports to the US) |
 
 ## India
 
@@ -50,6 +50,8 @@ output (requests to them return 403).
 - India macro → check BOTH `mospi` and `rbi`
 - Trade-war / commodity-flow stories → `census` + `china_customs` +
   `india_trade` cover the same flows from each country's own books
+  (until `china_customs` data loads, the `census` mirror stands in for
+  the China side)
 - Cross-country comparisons → `imf` / `worldbank`
 - Company-specific → `market` and `earnings` subcommands (not SQL schemas)
 

--- a/references/sql-guide.md
+++ b/references/sql-guide.md
@@ -28,9 +28,10 @@ The `context` subcommand returns the full DDL.
   nothing.
 - **`dataset_code` is lowercase** — use ILIKE or lowercase literals.
 - The server rewrites `series_title` to
-  `COALESCE(human_friendly_title, series_title)` automatically and
-  normalizes frequency filters; the response's `transformed_query` shows
-  what actually ran.
+  `COALESCE(human_friendly_title, series_title)` automatically, normalizes
+  frequency filters, and turns `data_points.series_id` pattern filters into
+  semi-joins on `series`; the response's `transformed_query` shows what
+  actually ran.
 - Results come back enriched with `constituent_series` metadata
   (titles, units, source) for every series_id touched — use it for chart
   source attribution.
@@ -70,6 +71,30 @@ LIMIT 20
 Prefer filtering on indexed columns (`series_id`, `dataset_code`) over text
 scans. For text searches use two steps: find series_ids first, then fetch
 their data.
+
+## Never pattern-match `series_id` on `data_points`
+
+`data_points` is enormous and its index does not serve LIKE/ILIKE — even an
+anchored pattern (`series_id LIKE 'us\_census\_hs\_M\_10d\_280530%'`) scans
+the whole table and dies at the 30s timeout. The same pattern against the
+small `series` catalog is fast.
+
+The server rewrites WHERE-clause LIKE/ILIKE on `data_points.series_id` into
+`series_id IN (SELECT series_id FROM series WHERE ...)` automatically (the
+response's `transformed_query` shows it), so those queries now run via the
+index. But the rewrite covers WHERE clauses only — a pattern inside a
+projection (`SUM(CASE WHEN series_id LIKE '%\_5700' THEN value END)`) is
+untouched, and is fine *only if* the WHERE clause already narrows the rows.
+When in doubt, resolve ids explicitly first:
+
+```sql
+-- Step 1 (fast): resolve the id list on the catalog
+SELECT series_id FROM series WHERE series_id LIKE 'us\_census\_hs\_M\_10d\_280530%'
+
+-- Step 2 (fast): fetch with an explicit IN list — uses the index
+SELECT series_id, time, value FROM data_points
+WHERE series_id IN ('...', '...')
+```
 
 ## National vs. sub-national series — the classic trap
 

--- a/scripts/factiq.py
+++ b/scripts/factiq.py
@@ -83,7 +83,7 @@ def http_json(
     req = urllib.request.Request(url, data=data, method=method)
     req.add_header("Content-Type", "application/json")
     # Cloudflare blocks urllib's default python-urllib/x.y user-agent outright.
-    req.add_header("User-Agent", "factiq-cli/0.2 (+https://github.com/defog-ai/factiq-skill)")
+    req.add_header("User-Agent", "factiq-cli/0.3 (+https://github.com/defog-ai/factiq-skill)")
     if token:
         req.add_header("Authorization", f"Bearer {token}")
     try:
@@ -149,7 +149,16 @@ def emit(payload: dict, args: argparse.Namespace) -> None:
 
     The --out pattern keeps large result sets out of the orchestrator's
     context: full data goes to disk, stdout carries only the shape.
+
+    Tool-level failures (SQL errors, statement timeouts) arrive as HTTP 200
+    with an `error` body. Surface them like any other failure — stderr and a
+    non-zero exit — and never write them to --out, where a poisoned file
+    crashes downstream parsing long after the failed call.
     """
+    if isinstance(payload, dict) and payload.get("error"):
+        print(json.dumps(payload, indent=2, default=str), file=sys.stderr)
+        sys.exit(4)
+
     out = getattr(args, "out", None)
     if out:
         with open(out, "w") as f:


### PR DESCRIPTION
Skill-side fixes for #3. Companion server-side PR: defog-ai/worlddb#843 (the LIKE→semi-join rewrite, `max_rows` in sample mode, and the `us_census_hs` description fix).

## Item 2 — SQL errors inside `--out` files failed silently

`emit()` now detects an `error`-keyed payload before doing anything else: it prints the payload to **stderr**, exits with code **4**, and never writes the `--out` file. No more poisoned out-files crashing downstream parsing two steps later. Exit codes are now: 2 = HTTP error, 3 = rate limit/quota, 4 = server-reported tool error.

## Item 1 — `data_points` LIKE pitfall documented

New sql-guide section: never pattern-match `series_id` on `data_points`. The server now rewrites WHERE-clause patterns into a semi-join on `series` automatically (worlddb#843), but projection patterns (`CASE WHEN series_id LIKE ...`) are not rewritten — the explicit resolve-ids-then-`IN` two-step is documented for those cases.

## Items 4 + 5 — dataset gotchas documented

- `us_census_hs`: quantity `_qty` series exist only at the 10-digit level; 6-digit lines are value-only.
- `china_customs`: no data loaded yet — use the `us_census_hs` mirror in `census` for China–US trade.
- `search` tip: prefer short stems (`rare`, not `rare earth`) since substring matching misses differently-worded titles.

Plugin version bumped to 0.3.0 (CLI behavior change).

Closes #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)