### PR TITLE
Emit sources + lineage so shared charts show provenance

### DIFF
--- a/references/chart-spec.md
+++ b/references/chart-spec.md
@@ -82,6 +82,53 @@ If the claim depends on a time window, keep the range in the title.
 - `subtitle`, `description`, `notes[]`, `footnote` — optional supporting
   text.
 
+## Data lineage (`lineage`)
+
+Always include a `lineage` DAG in the spec. The share page renders it as a
+"How we built this" panel; without it the chart shows only the one-line
+Data Source citation. It records the steps you actually took — searches,
+SQL, computations — ending in a single `output` node:
+
+```json
+"lineage": {
+  "root_id": "out",
+  "nodes": [
+    {
+      "id": "sql1", "type": "sql", "inputs": [],
+      "title": "BLS unemployment rate",
+      "summary": "Monthly LNS14000000 from bls.data_points, 2019–2025",
+      "detail": "SELECT date, value FROM data_points WHERE series_id = 'LNS14000000' ...",
+      "code": "SELECT date, value FROM data_points WHERE series_id = 'LNS14000000' ...",
+      "code_language": "sql",
+      "series_refs": [
+        { "schema_name": "bls", "series_id": "LNS14000000", "title": "Unemployment Rate" }
+      ]
+    },
+    {
+      "id": "calc", "type": "code", "inputs": ["sql1"],
+      "title": "Computed YoY change",
+      "summary": "12-month difference on the monthly rate",
+      "detail": "", "code": "yoy = rate - rate.shift(12)", "code_language": "python"
+    },
+    {
+      "id": "out", "type": "output", "inputs": ["calc"],
+      "title": "US unemployment rate, 2019–2025",
+      "summary": "Line chart of the monthly rate with YoY overlay",
+      "detail": ""
+    }
+  ]
+}
+```
+
+Node fields: `id`, `type` (`sql | series | code | web | market | output`),
+`title`, `summary`, `detail`, `inputs` (upstream node ids — `[]` for leaves).
+Optional per type: `code` + `code_language` (shown as a code block — put the
+exact SQL or Python you ran here), `series_refs[]`
+(`{schema_name, series_id, title}`, rendered as links to the series pages),
+`web_sources[]` (`{url, title}`) for `web` nodes, and `market_ticker` for
+`market` nodes. One node per real step; exactly one `output` node, referenced
+by `root_id`.
+
 ## Workflow
 
 1. Fetch full data to disk: `... sql --full --out /tmp/data.json` (or
@@ -91,6 +138,8 @@ If the claim depends on a time window, keep the range in the title.
    `chart.json`. Sort rows by the x value first — some endpoints return
    data reverse-chronological, which would render a backwards x-axis.
 3. Validate locally that every `series[].key` and `xField.key` exists in the
-   `data` rows.
+   `data` rows, and that the spec carries both `sources[]` and a `lineage`
+   DAG (see above) — they are what the share page shows as the Data Source
+   line and the "How we built this" panel.
 4. `python3 scripts/factiq.py share-chart --spec chart.json --question "..."`
 5. Return the `shareUrl`.

--- a/scripts/factiq.py
+++ b/scripts/factiq.py
@@ -367,6 +367,18 @@ def cmd_share_chart(args: argparse.Namespace) -> None:
     ]
     if missing:
         fail(f"Chart spec is missing required field(s): {', '.join(missing)}")
+    if not chart.get("sources"):
+        print(
+            "warning: chart spec has no 'sources' — the shared page will show no "
+            "Data Source citation (see references/chart-spec.md)",
+            file=sys.stderr,
+        )
+    if not chart.get("lineage"):
+        print(
+            "warning: chart spec has no 'lineage' — the shared page will show no "
+            "'How we built this' panel (see references/chart-spec.md)",
+            file=sys.stderr,
+        )
     if args.question:
         body["question"] = args.question
     body.setdefault("source", "factiq-skill")


### PR DESCRIPTION
## Problem

Charts published via the skill's `share-chart` showed **no source attribution and no data-lineage section** on the share page.

Root cause is split across the stack:
1. The skill already attaches `sources[]` to the ChartSpec, but the worlddb-ui share page never rendered them (fixed separately in worlddb-ui — the DataCard header now renders a "Data Source" citation from `chart.sources`).
2. The "How we built this" panel is driven by a `lineage` DAG in the ChartSpec, which only the server-side agent used to produce. Skill-published specs had no `lineage`, so the lineage button rendered nothing.

## Changes

- `references/chart-spec.md`: document the `lineage` DAG format (node types, `series_refs`, `code`/`code_language`, `web_sources`, single `output` node + `root_id`) with a worked example, and instruct the model to always include it; extend the pre-publish validation step to cover `sources` and `lineage`.
- `scripts/factiq.py`: `share-chart` now prints a non-fatal stderr warning when the spec lacks `sources` or `lineage`, so the orchestrating model catches the omission at publish time.

## Verified

Published a spec with `sources` + `lineage` to a local worlddb-ui dev server: the share page shows "Data Source: Bureau of Labor Statistics" and a working "How we built this" sidebar rendering the SQL → output DAG. A spec without `lineage` publishes fine and triggers the new warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)