### PR TITLE
Add report mode: share-report subcommand + quick-chart/report selection in /factiq:ask

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,11 +1,13 @@
 {
   "name": "factiq",
-  "owner": { "name": "Defog" },
+  "owner": {
+    "name": "Defog"
+  },
   "plugins": [
     {
       "name": "factiq",
       "source": "./",
-      "description": "Answer economic and financial data questions with real data from FactIQ — and publish shareable charts."
+      "description": "Answer economic and financial data questions with real data from FactIQ — and publish shareable charts and reports."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,8 @@
 {
   "name": "factiq",
-  "description": "Answer economic and financial data questions with real data from FactIQ — and publish shareable charts.",
-  "version": "0.3.0",
-  "author": { "name": "Defog" }
+  "description": "Answer economic and financial data questions with real data from FactIQ — and publish shareable charts and reports.",
+  "version": "0.4.0",
+  "author": {
+    "name": "Defog"
+  }
 }

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,19 +7,30 @@ description: >
   customs, India MOSPI/RBI/trade, Singapore, IMF, World Bank), stock quotes
   and fundamentals, commodities/forex, and earnings-call intelligence. Use
   when the user asks about unemployment, inflation, GDP, trade flows, energy,
-  wages, markets, or wants a shareable economic chart. You orchestrate the
-  whole analysis yourself — discover series, query SQL, compute, build the
-  chart spec, publish a share link.
+  wages, markets, or wants a shareable economic chart or a full multi-section
+  research report. You orchestrate the whole analysis yourself — discover
+  series, query SQL, compute, then publish either a single chart or a
+  fully formed report as a share link.
 allowed-tools: Bash(python3:*), Bash(python:*), Read, Write
 ---
 
 # FactIQ Data Tools
 
 You are the analyst. FactIQ provides authenticated HTTP data tools (catalog
-search, read-only SQL, series lookup, market data, earnings search) and a
-chart-publishing endpoint. There is no server-side agent in this loop: you
+search, read-only SQL, series lookup, market data, earnings search) and two
+publishing endpoints — a single shareable chart, or a fully formed
+multi-section report. There is no server-side agent in this loop: you
 decompose the question, find the data, do the math with your own tokens, and
-build the chart.
+author the output.
+
+Two output modes:
+
+- **Quick chart** (`share-chart`) — one focused chart. Default for questions
+  about a single metric or comparison.
+- **Detailed report** (`share-report`) — summary + sections of narrative and
+  charts + methodology, rendered on FactIQ's share-report page exactly like
+  the in-house agent's reports. For broad or analytical questions. See
+  **Detailed reports** below.
 
 All access goes through the bundled CLI — no codebase or database access is
 needed:
@@ -72,6 +83,7 @@ in the environment first, then `api_key` in `~/.factiq/config.json`.
 | `market FUNCTION [--symbol AAPL] [--interval] [--outputsize full]` | Quotes, daily/weekly/monthly series, fundamentals (OVERVIEW, INCOME_STATEMENT, EARNINGS), FX, commodities (WTI, BRENT, GOLD), SYMBOL_SEARCH. |
 | `earnings "QUERY" [--target sections\|themes\|qa_exchanges] [--companies AAPL,MSFT] [--quarter 2025Q4]` | Full-text search over earnings-call intelligence. |
 | `share-chart --spec chart.json [--question "..."]` | Publish a ChartSpec, returns `{shareUrl}`. |
+| `share-report --report report.json [--question "..."] [--model "..."]` | Publish a multi-section report as a public shared run, returns `{shareUrl, ...}`. |
 
 ## Orchestration workflow
 
@@ -98,9 +110,41 @@ in the environment first, then `api_key` in `~/.factiq/config.json`.
    for a server-side code interpreter; there is none in this loop.
 5. **Recent market data.** The DB lags for very recent market/price data —
    use `market` for current quotes, commodities, and FX.
-6. **Build the chart.** Write a ChartSpec JSON (see
+6. **Publish.** Quick-chart mode: write a ChartSpec JSON (see
    `references/chart-spec.md`) with wide-format data rows, then
-   `share-chart --spec chart.json`. Return the `shareUrl` to the user.
+   `share-chart --spec chart.json`. Report mode: write a report JSON (see
+   `references/report-spec.md` and **Detailed reports** below), then
+   `share-report --report report.json`. Either way, return the `shareUrl`
+   to the user.
+
+## Detailed reports
+
+A report is a public, fully rendered FactIQ research page: a bulleted
+summary up top, then sections that pair narrative with charts, then
+methodology notes. You author the whole thing — every chart's data rows,
+every narrative claim — from data you actually fetched in this session.
+The JSON format, per-chart fields, and a worked example live in
+`references/report-spec.md`. Read that file before writing the report.
+
+Ground rules:
+
+- **2–5 sections, 1–2 charts each** is the sweet spot (server caps: 12
+  sections, 16 charts). Each section should make one claim its charts prove.
+- **Chart titles state the finding** ("Health care added 652k jobs in 2024 —
+  triple tech's losses"), not the topic ("Jobs by sector").
+- **Narratives are plain text** — markdown is not rendered on the report
+  page, so `**bold**` shows up as literal asterisks.
+- **Cite sources and lineage.** Every chart should carry `sources` (the
+  datasets behind it) and `lineage` (the SQL/computation steps you actually
+  ran). Charts without lineage get a generic "uploaded data" stub — fine,
+  but real lineage makes the "How we built this" panel meaningful.
+- **Don't pad.** If the data only supports one chart, publish a quick chart
+  instead of inflating a report.
+
+`share-report` validates locally, POSTs to `/tools/report`, and prints the
+server response plus a `shareUrl` composed from your configured web origin.
+The report appears in your FactIQ history and can be forked by anyone who
+opens the share link.
 
 ## Context budget — sampled previews and `--out`
 
@@ -142,6 +186,10 @@ series list to fetch the rest.
   (`series_id`, `dataset_code`) instead of scanning titles across the table,
   and never pattern-match `series_id` on `data_points` — resolve ids from
   `series` first (see the pitfall in `references/sql-guide.md`).
+- **share-report 422** — the server re-validates the report against its real
+  chart schemas and names the failing field paths (e.g.
+  `sections[1].charts[0].x_column`). Fix the named fields in the JSON and
+  re-run; nothing was published.
 
 ## References
 
@@ -149,5 +197,8 @@ series list to fetch the rest.
   (frequency literals, national vs sub-national, pivots, tabular data).
 - `references/chart-spec.md` — ChartSpec format, chart-type selection, a
   worked share-chart example.
+- `references/report-spec.md` — report JSON format for `share-report`:
+  sections, per-chart fields, sources/lineage authoring, limits, a worked
+  example.
 - `references/schemas.md` — what lives in each schema. The `context`
   subcommand is the live, authoritative version.

--- a/commands/ask.md
+++ b/commands/ask.md
@@ -1,15 +1,40 @@
 ---
-description: Answer a data question with FactIQ and publish a shareable chart
+description: Answer a data question with FactIQ — a quick chart or a full report
 argument-hint: "<question, e.g. How has US unemployment changed since 2019?>"
 disable-model-invocation: true
-allowed-tools: Bash(python3:*), Bash(python:*), Read, Write
+allowed-tools: Bash(python3:*), Bash(python:*), Read, Write, AskUserQuestion
 ---
 
 Answer this question with real data from FactIQ:
 
 > $ARGUMENTS
 
-Read `${CLAUDE_PLUGIN_ROOT}/SKILL.md` and follow its orchestration workflow
-exactly (context → discover → fetch → compute → chart → share). Finish by
-returning the share URL and a short narrative of what the data shows. If no
-question was provided above, ask the user what they want to know.
+Read `${CLAUDE_PLUGIN_ROOT}/SKILL.md` first. If no question was provided
+above, ask the user what they want to know.
+
+**Pick the output mode before doing any data work:**
+
+- **Quick chart** — one focused chart plus a short narrative. Right when the
+  question names a single metric, series, or comparison: "How has X
+  changed?", "X vs Y", "What is the current Z?".
+- **Detailed report** — a multi-section shareable report (summary, 2–5
+  sections of narrative + charts, methodology notes). Right when the
+  question is broad or analytical: "the state of the US labor market",
+  "what's driving inflation", "deep dive", or the user says report /
+  analysis / comprehensive.
+
+If the question clearly fits one mode, proceed without asking. Only when it
+is genuinely ambiguous — broad enough that a report would add value, but a
+single chart could plausibly satisfy it — use the AskUserQuestion tool to
+offer the two modes, noting that the report takes noticeably longer and uses
+more of their tokens and FactIQ tool quota.
+
+Then follow SKILL.md's orchestration workflow (context → discover → fetch →
+compute) and finish per the mode:
+
+- **Quick chart** → build a ChartSpec (`references/chart-spec.md`), publish
+  with `share-chart`, and return the share URL plus a short narrative of
+  what the data shows.
+- **Detailed report** → follow SKILL.md's **Detailed reports** section and
+  `references/report-spec.md`, publish with `share-report`, and return the
+  share URL plus the report's key findings.

--- a/references/report-spec.md
+++ b/references/report-spec.md
@@ -1,0 +1,222 @@
+# Report JSON and share-report
+
+`share-report --report report.json` POSTs the report to `POST /tools/report`
+(API-key auth) and returns the server response plus a `shareUrl`. The server
+stores it as a completed, publicly shared FactIQ run, so the link renders on
+the standard share-report page: bulleted summary, sections of narrative +
+charts, per-chart Data Source line and "How we built this" lineage panel,
+methodology notes. The run also appears in your FactIQ history, and anyone
+opening the link can fork it into their own account.
+
+The CLI accepts either a bare report (`{summary, sections, ...}`, pass
+`--question` on the command line) or a full request envelope:
+
+```json
+{
+  "question": "How has US unemployment evolved since 2022?",
+  "model": "claude-sonnet-4-6 (factiq-skill)",
+  "report": { ... }
+}
+```
+
+`model` is a free-text label for who authored the report — pass your own
+model name.
+
+## Report structure
+
+```json
+{
+  "summary": "2–4 crisp sentences. Each sentence renders as its own summary bullet.",
+  "sections": [
+    {
+      "heading": "Section title",
+      "narrative": "Plain-text paragraph(s) shown beside the section's charts.",
+      "charts": [ { ...chart... } ]
+    }
+  ],
+  "methodology_notes": "Optional caveats: adjustments, survey vintages, definitions."
+}
+```
+
+- `summary` — required, ≤5,000 chars. Rendered as bullets, one per sentence.
+- `sections` — 1–12 (2–5 is the sweet spot). Each needs a `heading`;
+  `narrative` and `charts` are optional per section, but the report as a
+  whole needs **at least one chart** and at most **16 charts total**.
+- `narrative` — **plain text, no markdown**: the report page renders it
+  verbatim, so `**bold**` shows literal asterisks. ≤30,000 chars.
+
+## Charts
+
+`chart_type`: `line | bar | table | bubble | small_multiples | stacked_area
+| map | heatmap`. **Stick to `line`, `bar`, and `table`** — they take the
+simple tabular format below. The other types pass through with the in-house
+agent's full hydrated config structure, which is not documented here.
+
+Tabular chart fields:
+
+| Field | Required | Notes |
+|---|---|---|
+| `chart_type` | yes | `line`, `bar`, or `table` |
+| `title` | yes | The finding, with numbers — same rules as ChartSpec titles |
+| `columns` | yes | Column names, ≤40 |
+| `data` | yes | Rows, ≤1,200: arrays matching `columns` **or** objects keyed by column name |
+| `x_column` | line/bar | One of `columns` (tables default to the first column) |
+| `y_columns` | line/bar | Subset of `columns` (tables default to the rest) |
+| `units` | no | Y-axis label, e.g. `"Percent"` |
+| `subtitle` | no | E.g. `"Seasonally adjusted, monthly"` |
+| `annotations` | no | `[{"date": "<x value>", "text": "..."}]`, used sparingly |
+| `sources` | recommended | See below |
+| `lineage` | recommended | See below |
+| `generation_methodology` | no | One sentence on how the data was assembled |
+
+For time series, `x_column` values should be ISO date strings sorted
+ascending — some endpoints return reverse-chronological rows, which would
+render a backwards x-axis. Use `null` for gaps; don't drop rows. More than
+~300 points per line renders slowly — thin to monthly/quarterly first.
+
+### Sources
+
+```json
+"sources": [
+  {
+    "name": "Bureau of Labor Statistics",
+    "program": "Current Population Survey",
+    "type": "database",
+    "urls": ["/series/bls::LNS14000000"],
+    "titles": ["Unemployment Rate (LNS14000000)"]
+  }
+]
+```
+
+`name` is required; `type` is `database | web | derived` (default
+`database`). For `database` sources, `urls` are site-relative series links
+(`/series/{schema}::{series_id}`) with matching `titles`. Use `derived` for
+metrics you computed (YoY, indexed, ratios) and `web` for web research.
+
+### Lineage
+
+Same DAG format as ChartSpec lineage (see `references/chart-spec.md` —
+nodes with `id`, `type`, `title`, `summary`, `detail`, `inputs`, optional
+`code`/`code_language`/`series_refs`, exactly one `output` node referenced
+by `root_id`). Record the SQL and computations you actually ran. A chart
+uploaded without `lineage` gets a one-node "uploaded chart data" stub, so
+the panel still renders — but says nothing useful.
+
+## Validation and limits
+
+The CLI pre-checks the basics; the server then validates against the real
+chart schemas and 422s with the failing field paths (e.g.
+`sections[1].charts[0].x_column: Field required`). Fix and re-run — nothing
+is published on a 422. Server caps: 12 sections, 16 charts, 1,200 rows and
+40 columns per chart, 30k chars per narrative, 5k for the summary.
+
+## Worked example
+
+```json
+{
+  "question": "How has US unemployment evolved since 2022?",
+  "model": "claude-sonnet-4-6 (factiq-skill)",
+  "report": {
+    "summary": "US unemployment climbed from a 54-year low of 3.4% in April 2023 to 4.2% by late 2024, but the rise reflects labor-force re-entry rather than layoffs. Job openings cooled without a spike in claims.",
+    "sections": [
+      {
+        "heading": "The headline rate bottomed in 2023",
+        "narrative": "The unemployment rate's drift upward from mid-2023 came alongside rising participation, which is why economists read it as normalization rather than deterioration.",
+        "charts": [
+          {
+            "chart_type": "line",
+            "title": "US unemployment rose from 3.4% (Apr 2023) to 4.2% (Nov 2024)",
+            "subtitle": "Seasonally adjusted, monthly",
+            "x_column": "date",
+            "y_columns": ["unemployment_rate"],
+            "columns": ["date", "unemployment_rate"],
+            "units": "Percent",
+            "data": [
+              ["2022-01-01", 4.0],
+              ["2023-04-01", 3.4],
+              ["2024-11-01", 4.2]
+            ],
+            "annotations": [{ "date": "2023-04-01", "text": "54-year low of 3.4%" }],
+            "sources": [
+              {
+                "name": "Bureau of Labor Statistics",
+                "program": "Current Population Survey",
+                "type": "database",
+                "urls": ["/series/bls::LNS14000000"],
+                "titles": ["Unemployment Rate (LNS14000000)"]
+              }
+            ],
+            "generation_methodology": "Headline U-3 rate, seasonally adjusted.",
+            "lineage": {
+              "root_id": "output",
+              "nodes": [
+                {
+                  "id": "sql_1",
+                  "type": "sql",
+                  "title": "Query unemployment series",
+                  "summary": "Pulled the monthly U-3 unemployment rate from the BLS schema.",
+                  "detail": "",
+                  "inputs": [],
+                  "code": "SELECT date, value FROM data_points WHERE series_id = 'LNS14000000' ORDER BY date",
+                  "code_language": "sql",
+                  "series_refs": [
+                    { "schema_name": "bls", "series_id": "LNS14000000", "title": "Unemployment Rate" }
+                  ]
+                },
+                {
+                  "id": "output",
+                  "type": "output",
+                  "title": "Plot headline rate",
+                  "summary": "Single line with the April 2023 low annotated.",
+                  "detail": "",
+                  "inputs": ["sql_1"]
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "heading": "Sector contributions",
+        "narrative": "Health care and government did the heavy lifting on payrolls through 2024 while tech shed jobs.",
+        "charts": [
+          {
+            "chart_type": "bar",
+            "title": "Health care added 652k jobs in 2024 — triple tech's losses",
+            "x_column": "sector",
+            "y_columns": ["jobs_added_thousands"],
+            "columns": ["sector", "jobs_added_thousands"],
+            "units": "Thousands of jobs",
+            "data": [
+              { "sector": "Health care", "jobs_added_thousands": 652 },
+              { "sector": "Information (tech)", "jobs_added_thousands": -98 }
+            ],
+            "sources": [
+              {
+                "name": "Bureau of Labor Statistics",
+                "program": "Current Employment Statistics (CES)",
+                "type": "database"
+              }
+            ],
+            "generation_methodology": "Year-over-year change in payroll employment by supersector."
+          }
+        ]
+      }
+    ],
+    "methodology_notes": "All figures seasonally adjusted. Sector payrolls from the establishment survey; the headline rate from the household survey — the two can diverge month to month."
+  }
+}
+```
+
+## Workflow
+
+1. Do the full data work first (context → discover → fetch `--full --out` →
+   compute locally). Every number in the report must come from data you
+   fetched this session.
+2. Outline: 2–5 section claims, one or two charts each that prove the claim.
+3. Write a local Python script that reads the `--out` files and emits
+   `report.json` — don't hand-type data rows.
+4. `python3 scripts/factiq.py share-report --report report.json`
+   (add `--question "..."` if the file is a bare report, and `--model` with
+   your model name).
+5. Return the `shareUrl` and the report's key findings.

--- a/scripts/factiq.py
+++ b/scripts/factiq.py
@@ -91,7 +91,7 @@ def http_json(
     req = urllib.request.Request(url, data=data, method=method)
     req.add_header("Content-Type", "application/json")
     # Cloudflare blocks urllib's default python-urllib/x.y user-agent outright.
-    req.add_header("User-Agent", "factiq-cli/0.3 (+https://github.com/defog-ai/factiq-skill)")
+    req.add_header("User-Agent", "factiq-cli/0.4 (+https://github.com/defog-ai/factiq-skill)")
     if token:
         req.add_header("Authorization", f"Bearer {token}")
     try:

--- a/scripts/factiq.py
+++ b/scripts/factiq.py
@@ -393,6 +393,91 @@ def cmd_share_chart(args: argparse.Namespace) -> None:
     print(json.dumps(response, indent=2))
 
 
+REPORT_CHART_TYPES = {
+    "line",
+    "bar",
+    "table",
+    "bubble",
+    "small_multiples",
+    "stacked_area",
+    "map",
+    "heatmap",
+}
+REPORT_TABULAR_TYPES = {"line", "bar", "table"}
+
+
+def cmd_share_report(args: argparse.Namespace) -> None:
+    """Publish a multi-section report via POST /tools/report.
+
+    Validation here is a fast local pre-flight only — the server re-validates
+    everything against the real chart schemas and returns a 422 naming the
+    failing field paths.
+    """
+    try:
+        with open(args.report) as f:
+            payload = json.load(f)
+    except OSError as exc:
+        fail(f"Cannot read report {args.report}: {exc}")
+    except json.JSONDecodeError as exc:
+        fail(f"Report {args.report} is not valid JSON: {exc}")
+
+    # Accept either a bare report {summary, sections, ...} or a full
+    # {question, report, model} request payload.
+    body = payload if "report" in payload else {"report": payload}
+    if args.question:
+        body["question"] = args.question
+    if args.model:
+        body["model"] = args.model
+    body.setdefault("model", "factiq-skill")
+    if not str(body.get("question", "")).strip():
+        fail("Provide --question (or a top-level 'question' in the report file).")
+
+    report = body["report"]
+    if not str(report.get("summary", "")).strip():
+        fail("Report needs a non-empty 'summary'.")
+    sections = report.get("sections")
+    if not isinstance(sections, list) or not sections:
+        fail("Report needs a non-empty 'sections' list.")
+
+    chart_count = 0
+    for i, section in enumerate(sections):
+        if not str(section.get("heading", "")).strip():
+            fail(f"sections[{i}] needs a 'heading'.")
+        for j, chart in enumerate(section.get("charts") or []):
+            chart_count += 1
+            where = f"sections[{i}].charts[{j}]"
+            if chart.get("chart_type") not in REPORT_CHART_TYPES:
+                fail(f"{where}: chart_type must be one of {sorted(REPORT_CHART_TYPES)}")
+            if not str(chart.get("title", "")).strip():
+                fail(f"{where}: 'title' is required and should state the finding")
+            if chart.get("chart_type") in REPORT_TABULAR_TYPES and not (
+                chart.get("columns") and chart.get("data")
+            ):
+                fail(f"{where}: line/bar/table charts need 'columns' and 'data'")
+            if not chart.get("sources"):
+                print(
+                    f"warning: {where} has no 'sources' — the report will show no "
+                    "Data Source citation (see references/report-spec.md)",
+                    file=sys.stderr,
+                )
+            if not chart.get("lineage"):
+                print(
+                    f"warning: {where} has no 'lineage' — its 'How we built this' "
+                    "panel will be a generic stub (see references/report-spec.md)",
+                    file=sys.stderr,
+                )
+    if chart_count == 0:
+        fail("Report needs at least one chart across its sections.")
+
+    response = api_request(args, "POST", "/tools/report", body)
+    # Compose the share URL from the CLI's own web origin so FACTIQ_WEB_URL /
+    # --web-url overrides (e.g. localhost) carry through.
+    config = load_config()
+    share_path = response.get("share_path") or f"/share/{response.get('share_id')}"
+    response["shareUrl"] = web_url(args, config) + share_path
+    print(json.dumps(response, indent=2))
+
+
 # ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
@@ -523,6 +608,22 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--spec", required=True, help="Path to chart spec JSON")
     p.add_argument("--question", help="Question shown with the shared chart")
     p.set_defaults(func=cmd_share_chart)
+
+    p = sub.add_parser(
+        "share-report",
+        help="Publish a multi-section report, get a share URL",
+        parents=[shared],
+    )
+    p.add_argument(
+        "--report",
+        required=True,
+        help="Path to report JSON (see references/report-spec.md)",
+    )
+    p.add_argument(
+        "--question", help="The question the report answers (overrides the file)"
+    )
+    p.add_argument("--model", help="Label for the model that authored the report")
+    p.set_defaults(func=cmd_share_report)
 
     return parser
 


### PR DESCRIPTION
## What

Two features:

### 1. `/factiq:ask` picks an output mode (and only asks when ambiguous)

`commands/ask.md` now classifies the question before any data work:

- **Quick chart** — single metric/comparison questions → existing `share-chart` flow
- **Detailed report** — broad/analytical questions ("state of the labor market", "deep dive") → new report flow

When the question clearly fits one mode it proceeds without asking; only genuinely ambiguous questions trigger an AskUserQuestion offering the two modes (noting the report costs more time/tokens/quota).

### 2. `share-report`: publish a fully formed report from the plugin

Users can now author a complete multi-section report **with their own tokens** (the local Claude orchestrates: discover → fetch → compute → write narrative + charts) and upload it so it renders on FactIQ's standard share-report page.

- New `share-report --report report.json [--question ...] [--model ...]` subcommand in `scripts/factiq.py`. It pre-validates locally (chart types, required fields per chart, ≥1 chart), warns on missing `sources`/`lineage`, POSTs to the backend's new `POST /tools/report` (defog-ai/worlddb#844), and composes `shareUrl` from the configured web origin so `FACTIQ_WEB_URL`/localhost overrides carry through.
- New `references/report-spec.md`: report JSON format, per-chart fields for line/bar/table, sources + lineage authoring, server limits (12 sections / 16 charts / 1,200 rows / 40 cols), gotchas (plain-text narratives — markdown isn't rendered; sort time series ascending), and a worked example.
- `SKILL.md`: documents the two output modes, adds a **Detailed reports** section with authoring ground rules, the `share-report` row in the subcommand table, and the 422 error contract.

## Testing

Against a local backend running the worlddb PR branch:

- Happy path: published a 2-section sample report → server stored it as a public run, share page renders correctly in the browser (summary bullets, line chart with annotation + lineage panel, bar chart, sources, methodology notes) with zero frontend changes.
- Local validation: bad `chart_type` → exit 1 with the field path, no network call.
- Server validation: line chart missing `x_column` passes pre-flight, server 422s naming `sections.0.charts.0...x_column: Field required`, exit 2, nothing published.
- `python3 -m py_compile` + `--help` smoke tests pass.

## Companion PR

- defog-ai/worlddb#844 — adds `POST /tools/report` (must deploy first; until then `share-report` against production 404s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)