### PR TITLE
Tighten lineage quality: formatted code + complete series_refs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — and publish shareable charts and reports.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Defog"
   }

--- a/SKILL.md
+++ b/SKILL.md
@@ -137,7 +137,10 @@ Ground rules:
 - **Cite sources and lineage.** Every chart should carry `sources` (the
   datasets behind it) and `lineage` (the SQL/computation steps you actually
   ran). Charts without lineage get a generic "uploaded data" stub — fine,
-  but real lineage makes the "How we built this" panel meaningful.
+  but real lineage makes the "How we built this" panel meaningful. Lineage
+  `code` renders verbatim in a code block, so write it as formatted
+  multi-line SQL/Python — never collapsed onto one line — and list **every**
+  series the step touched in `series_refs`, not a single representative one.
 - **Don't pad.** If the data only supports one chart, publish a quick chart
   instead of inflating a report.
 

--- a/references/chart-spec.md
+++ b/references/chart-spec.md
@@ -95,13 +95,14 @@ SQL, computations — ending in a single `output` node:
   "nodes": [
     {
       "id": "sql1", "type": "sql", "inputs": [],
-      "title": "BLS unemployment rate",
-      "summary": "Monthly LNS14000000 from bls.data_points, 2019–2025",
-      "detail": "SELECT date, value FROM data_points WHERE series_id = 'LNS14000000' ...",
-      "code": "SELECT date, value FROM data_points WHERE series_id = 'LNS14000000' ...",
+      "title": "BLS unemployment rates",
+      "summary": "Monthly U-3 and U-6 from bls.data_points, 2019–2025",
+      "detail": "",
+      "code": "SELECT date, series_id, value\nFROM data_points\nWHERE series_id IN ('LNS14000000', 'LNS13327709')\n  AND date >= '2019-01-01'\nORDER BY date",
       "code_language": "sql",
       "series_refs": [
-        { "schema_name": "bls", "series_id": "LNS14000000", "title": "Unemployment Rate" }
+        { "schema_name": "bls", "series_id": "LNS14000000", "title": "Unemployment Rate (U-3)" },
+        { "schema_name": "bls", "series_id": "LNS13327709", "title": "Total unemployed plus marginally attached (U-6)" }
       ]
     },
     {
@@ -113,7 +114,7 @@ SQL, computations — ending in a single `output` node:
     {
       "id": "out", "type": "output", "inputs": ["calc"],
       "title": "US unemployment rate, 2019–2025",
-      "summary": "Line chart of the monthly rate with YoY overlay",
+      "summary": "Line chart of U-3 and U-6 with YoY overlay",
       "detail": ""
     }
   ]
@@ -128,6 +129,21 @@ exact SQL or Python you ran here), `series_refs[]`
 `web_sources[]` (`{url, title}`) for `web` nodes, and `market_ticker` for
 `market` nodes. One node per real step; exactly one `output` node, referenced
 by `root_id`.
+
+Two rules the panel depends on:
+
+- **`code` is formatted, multi-line code.** It renders verbatim in a code
+  block — a query collapsed onto one line shows up as one unreadable line.
+  Embed real newlines (`\n` in the JSON string) exactly as you would
+  present the SQL or Python to a reader. The same goes for `code` on
+  `code`-type nodes: include the actual script lines you ran, not a
+  one-line paraphrase.
+- **`series_refs` is the complete list.** Include every series the step
+  actually used — every id in the query's `IN (...)` list or filter, with
+  its real title — not one representative example. Each ref becomes a link
+  on the share page; readers use them to audit the chart. If a query
+  aggregates a very large set (say 40+ series), list the largest
+  contributors and state the full count in `summary`.
 
 ## Workflow
 

--- a/references/report-spec.md
+++ b/references/report-spec.md
@@ -102,6 +102,19 @@ by `root_id`). Record the SQL and computations you actually ran. A chart
 uploaded without `lineage` gets a one-node "uploaded chart data" stub, so
 the panel still renders — but says nothing useful.
 
+Two rules carry over from chart-spec lineage and are worth repeating
+because reports get them wrong most often:
+
+- `code` renders verbatim in a code block — write it as **formatted,
+  multi-line** SQL/Python with real newlines (`\n` in the JSON string),
+  never collapsed onto one line. For `code`-type nodes include the actual
+  script lines you ran, not a one-line paraphrase.
+- `series_refs` lists **every** series the step used (each id in the
+  query's `IN (...)` list or filter, with its real title), not a single
+  representative one. Each ref renders as a clickable series link. For
+  very large aggregates (40+ series), list the largest contributors and
+  state the full count in `summary`.
+
 ## Validation and limits
 
 The CLI pre-checks the basics; the server then validates against the real
@@ -157,7 +170,7 @@ is published on a 422. Server caps: 12 sections, 16 charts, 1,200 rows and
                   "summary": "Pulled the monthly U-3 unemployment rate from the BLS schema.",
                   "detail": "",
                   "inputs": [],
-                  "code": "SELECT date, value FROM data_points WHERE series_id = 'LNS14000000' ORDER BY date",
+                  "code": "SELECT date, value\nFROM data_points\nWHERE series_id = 'LNS14000000'\nORDER BY date",
                   "code_language": "sql",
                   "series_refs": [
                     { "schema_name": "bls", "series_id": "LNS14000000", "title": "Unemployment Rate" }

--- a/scripts/factiq.py
+++ b/scripts/factiq.py
@@ -19,6 +19,7 @@ import argparse
 import getpass
 import json
 import os
+import re
 import stat
 import sys
 import time
@@ -344,6 +345,53 @@ def cmd_earnings(args: argparse.Namespace) -> None:
     emit(api_request(args, "POST", "/tools/earnings", body), args)
 
 
+# Quoted SQL literals that look like series ids (letters + digits, e.g.
+# 'LNS14000000' or 'us_census_hs_M_10d_2846100010_5700') — used to spot
+# lineage nodes whose series_refs list fewer series than the query touches.
+SERIES_ID_LITERAL_RE = re.compile(r"'([A-Za-z0-9_]{6,})'")
+
+
+def lint_lineage(lineage: object, where: str) -> None:
+    """Warn about lineage that will render poorly on the share page.
+
+    Warnings only — nothing here blocks publishing. The two defects the
+    page cannot fix itself: code collapsed onto a single line (rendered
+    verbatim in a code block) and series_refs listing one representative
+    series instead of every series the step used.
+    """
+    nodes = lineage.get("nodes") if isinstance(lineage, dict) else None
+    if not isinstance(nodes, list):
+        return
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        label = f"{where} lineage node '{node.get('id', '?')}'"
+        code = node.get("code")
+        code = code.strip() if isinstance(code, str) else ""
+        if len(code) > 80 and "\n" not in code:
+            print(
+                f"warning: {label} has its code collapsed onto one line — it "
+                "renders verbatim in a code block, so embed real newlines "
+                "(formatted SQL/Python)",
+                file=sys.stderr,
+            )
+        if node.get("type") == "sql" and code:
+            refs = node.get("series_refs") or []
+            ids_in_code = {
+                lit
+                for lit in SERIES_ID_LITERAL_RE.findall(code)
+                if any(c.isdigit() for c in lit) and any(c.isalpha() for c in lit)
+            }
+            if len(ids_in_code) > len(refs):
+                print(
+                    f"warning: {label} queries {len(ids_in_code)} series-like "
+                    f"ids but series_refs lists only {len(refs)} — list every "
+                    "series the query used (see the lineage rules in the "
+                    "references)",
+                    file=sys.stderr,
+                )
+
+
 def cmd_share_chart(args: argparse.Namespace) -> None:
     try:
         with open(args.spec) as f:
@@ -379,6 +427,8 @@ def cmd_share_chart(args: argparse.Namespace) -> None:
             "'How we built this' panel (see references/chart-spec.md)",
             file=sys.stderr,
         )
+    else:
+        lint_lineage(chart["lineage"], "chart spec")
     if args.question:
         body["question"] = args.question
     body.setdefault("source", "factiq-skill")
@@ -466,6 +516,8 @@ def cmd_share_report(args: argparse.Namespace) -> None:
                     "panel will be a generic stub (see references/report-spec.md)",
                     file=sys.stderr,
                 )
+            else:
+                lint_lineage(chart["lineage"], where)
     if chart_count == 0:
         fail("Report needs at least one chart across its sections.")
 


### PR DESCRIPTION
## Problem

Skill-published reports render a poor "How we built this" panel on the share page (e.g. [/share/9ef2945d2e1648429940adfbf4f51d68](https://www.factiq.com/share/9ef2945d2e1648429940adfbf4f51d68)):

- Lineage `code` is collapsed onto a single line — the panel renders it verbatim in a code block, so the SQL shows as one endless line.
- `series_refs` lists one representative series instead of every series the query touched — that report's SQL aggregates **27** series but lists **1** ref.

The docs were partly to blame: the worked examples in both spec references demonstrated single-line `code`, and nothing said `series_refs` must be complete.

## Fix

- **Docs**: spell out both rules in `SKILL.md`, `references/chart-spec.md`, and `references/report-spec.md` — `code` must be formatted multi-line SQL/Python with real newlines; `series_refs` must list every series the step used (with a top-contributors escape hatch for 40+ series aggregates). Worked examples updated to demonstrate both.
- **CLI**: new `lint_lineage` pre-flight in `share-chart`/`share-report` warns (without blocking) when a node's code is collapsed onto one line, or when a sql node's query references more series-like id literals than `series_refs` lists. Against the broken report above it emits:

  ```
  warning: sections[0].charts[0] lineage node 'sql_1' has its code collapsed onto one line — ...
  warning: sections[0].charts[0] lineage node 'sql_1' queries 27 series-like ids but series_refs lists only 1 — ...
  ```

- Plugin version bumped to 0.4.1.

The companion render-side fix (pretty-printing single-line SQL already stored in old reports) is defog-ai/worlddb-ui#917.

## Testing

Ran `lint_lineage` against the real lineage payload from the share above (warns on both defects, three warnings total) and against a well-formed two-series lineage (silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)