### PR TITLE
Surface SQL --full --out truncation in the stdout stub

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — and publish shareable charts and reports.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": {
     "name": "Defog"
   }

--- a/SKILL.md
+++ b/SKILL.md
@@ -161,10 +161,14 @@ python3 scripts/factiq.py sql --schema bls --query "..." --full --out /tmp/unemp
 ```
 
 `--out` writes the complete JSON to disk and prints only a stub
-(`{out, columns, row_count, ...}`). Then build the chart's `data` array from
-the file with a local Python script. SQL `--full` is capped at 5,000 rows
-server-side (`truncated: true` flags the cut) — narrow the date range or
-series list to fetch the rest.
+(`{out, columns, row_count, written_rows, ...}`). Then build the chart's
+`data` array from the file with a local Python script. SQL `--full` returns up
+to `--max-rows` rows (default **500**); raise it (e.g. `--max-rows 5000`) to
+fetch more. When the result is cut, the response sets `truncated: true` plus a
+`note`, both of which the stub now echoes — and `written_rows` (rows actually
+on disk) will be below `row_count` (the server's pre-truncation total). If you
+see truncation, narrow the query (date range, fewer series), aggregate
+server-side, or raise `--max-rows`.
 
 ## Errors and limits
 

--- a/scripts/factiq.py
+++ b/scripts/factiq.py
@@ -230,13 +230,38 @@ def emit(payload: dict, args: argparse.Namespace) -> None:
         with open(out, "w") as f:
             json.dump(payload, f, indent=2)
         stub = {"out": out}
-        for key in ("columns", "row_count", "total_row_count", "title", "schema_name"):
+        for key in (
+            "columns",
+            "row_count",
+            "total_row_count",
+            "title",
+            "schema_name",
+            "truncated",
+            "note",
+        ):
             if key in payload:
                 stub[key] = payload[key]
         rows = payload.get("results")
-        if isinstance(rows, list) and "row_count" not in stub:
-            stub["row_count"] = len(rows)
+        if isinstance(rows, list):
+            # Always surface how many rows actually landed in --out. When the
+            # server truncates, its row_count is the pre-truncation total, so
+            # an agent reading only the stub would otherwise have no signal
+            # that the written file holds a partial (and, with ORDER BY, a
+            # non-random) slice.
+            stub["written_rows"] = len(rows)
+            stub.setdefault("row_count", len(rows))
         print(json.dumps(stub, indent=2))
+        if payload.get("truncated"):
+            # Silent partial data is a correctness hazard, not an FYI — make
+            # it loud on stderr so it is hard to miss even when stdout is
+            # consumed programmatically.
+            written = len(rows) if isinstance(rows, list) else "?"
+            note = payload.get("note") or (
+                f"Result truncated: wrote {written} of "
+                f"{payload.get('row_count', '?')} rows to {out}. Narrow the "
+                "query or raise --max-rows to fetch the rest."
+            )
+            print(f"WARNING: {note}", file=sys.stderr)
     else:
         print(json.dumps(payload, indent=2, default=str))
 


### PR DESCRIPTION
Fixes #10.

## Problem

`sql --full --out file.json` silently truncates large result sets. The server returns a truncated `results` array (default cap 500 rows) alongside the **pre-truncation** `row_count` plus `truncated`/`note` fields. But the CLI's stdout stub dropped `truncated`/`note` and echoed the server's total `row_count`, so an agent reading only the stub — the documented, context-saving workflow — had no signal that the written file held a partial (and, with `ORDER BY`, non-random) slice. Sorts/aggregations then silently ran on incomplete data and the resulting analysis was wrong.

A secondary docs/behavior mismatch: SKILL.md claimed `--full` is capped at 5,000 rows server-side, but the real default is `--max-rows 500`.

## Changes

`scripts/factiq.py` (`emit`):
- Propagate `truncated` and `note` into the stdout stub.
- Add `written_rows` (rows actually written to `--out`) so a mismatch with the server's `row_count` is visible at a glance.
- Print the truncation note to **stderr** as a loud `WARNING`, since silent partial data is a correctness hazard.

`SKILL.md`:
- Reconcile the cap docs — `--full` returns up to `--max-rows` rows (default 500, raisable), not 5,000.

## Verification

Truncating query (default `--max-rows 500`, 800-row result):

```
WARNING: Result truncated to 500 of 800 rows. Narrow the query (date range, fewer series) to fetch the rest.
{
  "out": "/tmp/out10.json",
  "columns": ["series_id", "series_title"],
  "row_count": 800,
  "schema_name": "census",
  "truncated": true,
  "note": "Result truncated to 500 of 800 rows. ...",
  "written_rows": 500
}
```

Non-truncating query stays clean (no warning, no `truncated`/`note`, `written_rows == row_count`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)