### PR TITLE
Add dataset search/describe; make context lean by default

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — and publish shareable charts and reports.",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "author": {
     "name": "Defog"
   }

--- a/SKILL.md
+++ b/SKILL.md
@@ -76,8 +76,10 @@ in the environment first, then `api_key` in `~/.factiq/config.json`.
 
 | Command | Purpose |
 |---|---|
-| `context [--schemas bls,bea]` | Dataset catalog, per-dataset descriptions, and the shared table DDL. **Call once per session before anything else.** |
-| `search --schema bls --terms "unemployment rate"` | Title-substring catalog search (repeat `--schema`/`--terms` pairs for several schemas in one call). Includes `COMPOUND::` series. |
+| `context [--schemas bls,bea] [--full]` | Lean per-schema index + the shared table DDL. **Call once per session before anything else.** `--full` returns the heavy per-dataset description dump (rarely needed — use `describe` instead). |
+| `search-datasets --query "rare earth imports" [--schemas mospi,rbi] [--limit N]` | Keyword (BM25, not semantic) ranking of datasets across all schemas. **The first discovery step** — find the right `schema`+`dataset_code`. |
+| `describe SCHEMA DATASET_CODE` | Full metadata for one dataset: topic, methodology, release dates, base-change notice, available dimensions, example series. Call after `search-datasets`. |
+| `search --schema bls --terms "unemployment rate"` | Series-level title-substring search within a schema (repeat `--schema`/`--terms` pairs). Includes `COMPOUND::` series. |
 | `sql --schema bls --query "..." [--explore] [--full] [--max-rows N] [--out f.json]` | Read-only SELECT against one schema. Default output is a sampled preview. |
 | `series SCHEMA SERIES_ID [--from-year Y] [--to-year Y] [--full] [--out f.json]` | Fetch one series — timeseries, tabular, or `COMPOUND::` ids all work. |
 | `market FUNCTION [--symbol AAPL] [--interval] [--outputsize full]` | Quotes, daily/weekly/monthly series, fundamentals (OVERVIEW, INCOME_STATEMENT, EARNINGS), FX, commodities (WTI, BRENT, GOLD), SYMBOL_SEARCH. |
@@ -87,21 +89,22 @@ in the environment first, then `api_key` in `~/.factiq/config.json`.
 
 ## Orchestration workflow
 
-1. **Context first.** Run `context` (optionally `--schemas` once you know
-   which are relevant) to get dataset descriptions and the table DDL. If the
-   unfiltered call times out, retry with `--schemas` — the full schema list
-   is included either way. Schemas listed under `schemas_without_data` have
-   no rows loaded; skip them.
-2. **Discover broadly.** Survey every schema that could be relevant before
-   deep-diving into one — for India check both `mospi` and `rbi`; for the US
-   check `bls`, `bea`, `census`; energy means `eia`. Use `search` for
-   obvious title matches and exploration SQL (`sql --explore`) for everything
-   else. `search` is substring matching, not semantic — prefer short stems
-   (`rare`, not `rare earth`: BLS titles its rare-earth import price index
-   "precious, rare-earth, or radioactive"), and use exploration SQL on
-   the `series` and `dimensions` tables as the primary discovery tool. For
-   multi-source stories, actually fetch data from 2+ schemas, don't just
-   survey them.
+1. **Context first.** Run `context` once to get the compact per-schema index
+   and the table DDL. This is lean by design — it tells you what each schema
+   covers, not every dataset. Schemas listed under `schemas_without_data` have
+   no rows loaded; skip them. (You rarely need `--full`; use `describe` for
+   detail on a specific dataset.)
+2. **Find datasets, then drill in.** Run `search-datasets --query "..."` to
+   rank datasets across all schemas by keyword — this is the primary discovery
+   step. Survey every schema that could be relevant before committing: for
+   India check both `mospi` and `rbi` (pass `--schemas mospi,rbi`); for the US
+   check `bls`, `bea`, `census`; energy means `eia`. Once a dataset looks
+   right, `describe SCHEMA DATASET_CODE` for its dimensions and example
+   series, then find the exact series with `search --schema ... --terms ...`
+   (series-level, substring — prefer short stems like `rare`, not `rare
+   earth`) or exploration SQL (`sql --explore`) on the `series` and
+   `dimensions` tables. For multi-source stories, actually fetch data from 2+
+   schemas, don't just survey them.
 3. **Fetch in batches.** Once you know which series you need, issue all
    fetch calls together (multiple Bash calls in one turn). Use `series` for
    1–2 known ids; `sql` with a CASE-WHEN pivot for 3+ series or joins.
@@ -208,4 +211,5 @@ server-side, or raise `--max-rows`.
   sections, per-chart fields, sources/lineage authoring, limits, a worked
   example.
 - `references/schemas.md` — what lives in each schema. The `context`
-  subcommand is the live, authoritative version.
+  subcommand is the live, authoritative version; `search-datasets` /
+  `describe` drill into individual datasets on demand.

--- a/scripts/factiq.py
+++ b/scripts/factiq.py
@@ -359,7 +359,10 @@ def cmd_context(args: argparse.Namespace) -> None:
             args,
             "GET",
             "/tools/context",
-            params={"schemas": args.schemas},
+            params={
+                "schemas": args.schemas,
+                "full": "true" if args.full else None,
+            },
             timeout_hint=(
                 "Retry with --schemas to narrow the response "
                 "(e.g. --schemas bls,bea,census); the full schema list is "
@@ -368,6 +371,23 @@ def cmd_context(args: argparse.Namespace) -> None:
         ),
         args,
     )
+
+
+def cmd_search_datasets(args: argparse.Namespace) -> None:
+    body: dict = {"query": args.query, "limit": args.limit}
+    if args.schemas:
+        body["schemas"] = [s.strip() for s in args.schemas.split(",") if s.strip()]
+    emit(api_request(args, "POST", "/tools/search_datasets", body), args)
+
+
+def cmd_describe(args: argparse.Namespace) -> None:
+    path = (
+        "/tools/describe_dataset/"
+        + urllib.parse.quote(args.schema, safe="")
+        + "/"
+        + urllib.parse.quote(args.dataset_code, safe="")
+    )
+    emit(api_request(args, "GET", path), args)
 
 
 def cmd_search(args: argparse.Namespace) -> None:
@@ -670,11 +690,40 @@ def build_parser() -> argparse.ArgumentParser:
     p.set_defaults(func=cmd_whoami)
 
     p = sub.add_parser(
-        "context", help="Dataset catalog + table structure", parents=[shared]
+        "context",
+        help="Schema index + table structure (lean; --full for per-dataset dump)",
+        parents=[shared],
     )
     p.add_argument("--schemas", help="Comma-separated schema filter, e.g. bls,bea")
+    p.add_argument(
+        "--full",
+        action="store_true",
+        help="Return the heavy per-dataset description dump (default is the "
+        "compact schema index — use search-datasets/describe for detail)",
+    )
     p.add_argument("--out", help="Write full JSON to file, print a stub")
     p.set_defaults(func=cmd_context)
+
+    p = sub.add_parser(
+        "search-datasets",
+        help="Find datasets by keyword across all schemas (start here)",
+        parents=[shared],
+    )
+    p.add_argument("--query", required=True, help="Free-text search terms")
+    p.add_argument("--schemas", help="Comma-separated schema filter, e.g. mospi,rbi")
+    p.add_argument("--limit", type=int, default=15)
+    p.add_argument("--out")
+    p.set_defaults(func=cmd_search_datasets)
+
+    p = sub.add_parser(
+        "describe",
+        help="Full metadata for one dataset (after search-datasets)",
+        parents=[shared],
+    )
+    p.add_argument("schema")
+    p.add_argument("dataset_code")
+    p.add_argument("--out")
+    p.set_defaults(func=cmd_describe)
 
     p = sub.add_parser(
         "search", help="Series catalog search by title terms", parents=[shared]


### PR DESCRIPTION
## Problem

The skill called `context` once per session and dropped the **full per-dataset description dump** into the orchestrator's context up front — token-heavy, and scaling with the number of *datasets* (~1,840) rather than schemas. The agent then picked datasets by eyeballing that wall of text.

## Approach — progressive disclosure

Switch to on-demand discovery against the new worlddb `/tools` endpoints:

- **`context` is lean by default** — returns a compact per-schema index (org, country, what's here, dataset count) + the table DDL. `--full` returns the old per-dataset dump for back-compat.
- **`search-datasets --query "..." [--schemas ...] [--limit N]`** — keyword (BM25, not semantic) ranking of datasets across all schemas. The primary discovery step; geography terms route to the right country's source.
- **`describe SCHEMA DATASET_CODE`** — full metadata for one dataset: topic, methodology, release dates, base-change notice, live dimensions, example series.

`SKILL.md`'s subcommand table and the orchestration workflow are updated to the new flow: **context (lean) → search-datasets → describe → series `search` / `sql`**.

## Dependency

Requires the matching worlddb backend endpoints (`GET /tools/context?full=`, `POST /tools/search_datasets`, `GET /tools/describe_dataset/{schema}/{code}`): **defog-ai/worlddb#881**. Merge/deploy that first.

## Verification

- `factiq.py` parses; `--help`, `search-datasets --help`, and `describe --help` render correctly.
- Endpoints exercised against a local dev server via the matching backend PR: lean vs `--full` context, `search-datasets`, and `describe` all return as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
