### PR TITLE
Make skill-published charts editable via backend /shared-charts (DEF-1412)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -84,7 +84,7 @@ in the environment first, then `api_key` in `~/.factiq/config.json`.
 | `series SCHEMA SERIES_ID [--from-year Y] [--to-year Y] [--full] [--out f.json]` | Fetch one series — timeseries, tabular, or `COMPOUND::` ids all work. |
 | `market FUNCTION [--symbol AAPL] [--interval] [--outputsize full]` | Quotes, daily/weekly/monthly series, fundamentals (OVERVIEW, INCOME_STATEMENT, EARNINGS), FX, commodities (WTI, BRENT, GOLD), SYMBOL_SEARCH. |
 | `earnings "QUERY" [--target sections\|themes\|qa_exchanges] [--companies AAPL,MSFT] [--quarter 2025Q4]` | Full-text search over earnings-call intelligence. |
-| `share-chart --spec chart.json [--question "..."]` | Publish a ChartSpec, returns `{shareUrl}`. |
+| `share-chart --spec chart.json [--question "..."]` | Publish a ChartSpec (owned by your API key, editable from the UI), returns `{shareId, shareUrl}`. |
 | `share-report --report report.json [--question "..."] [--model "..."]` | Publish a multi-section report as a public shared run, returns `{shareUrl, ...}`. |
 
 ## Orchestration workflow

--- a/references/chart-spec.md
+++ b/references/chart-spec.md
@@ -1,8 +1,11 @@
 # ChartSpec and share-chart
 
-`share-chart --spec chart.json` POSTs the spec to FactIQ's web app and
-returns `{shareId, shareUrl}` — a live, rendered chart page. The CLI accepts
-either a bare ChartSpec or a `{chart: {...}, question: "..."}` envelope.
+`share-chart --spec chart.json` POSTs the spec to the FactIQ backend
+(API-key auth) and returns `{shareId, shareUrl}` — a live, rendered chart
+page. The chart is owned by your API key's user, so you can edit it in place
+and restore earlier versions from the UI on `/share-chart/<id>`. The CLI
+accepts either a bare ChartSpec or a `{chart: {...}, question: "..."}`
+envelope.
 
 ## Minimal valid spec
 

--- a/scripts/factiq.py
+++ b/scripts/factiq.py
@@ -551,14 +551,20 @@ def cmd_share_chart(args: argparse.Namespace) -> None:
         body["question"] = args.question
     body.setdefault("source", "factiq-skill")
 
+    # POST to the backend's editable, owner-tied store (DEF-1411/DEF-1412)
+    # instead of the legacy unauthenticated Vercel Blob route. api_request adds
+    # the API-key bearer token, so the chart is owned by the key's user and can
+    # be edited + version-restored from the UI on /share-chart/<id>. The backend
+    # sanitizes the payload (1200 rows / 40 cols / 400 chars) and enforces a
+    # ~2MB cap; it returns {shareId} only, so we build shareUrl from the web
+    # origin exactly as the frontend service does.
+    response = api_request(args, "POST", "/shared-charts", body)
+    share_id = response.get("shareId")
+    if not share_id:
+        fail(f"share-chart failed: no shareId in response: {response}")
     config = load_config()
-    target = web_url(args, config) + "/api/share-chart"
-    status, response = http_json(
-        "POST", target, body, timeout=getattr(args, "timeout", DEFAULT_TIMEOUT)
-    )
-    if status >= 400 or not response.get("shareUrl"):
-        fail(f"share-chart failed (HTTP {status}): {response}")
-    print(json.dumps(response, indent=2))
+    share_url = f"{web_url(args, config)}/share-chart/{share_id}"
+    print(json.dumps({"shareId": share_id, "shareUrl": share_url}, indent=2))
 
 
 REPORT_CHART_TYPES = {


### PR DESCRIPTION
## What

`cmd_share_chart` in `scripts/factiq.py` published single charts through the **legacy unauthenticated** `{web}/api/share-chart` Vercel Blob route. With no owner row in Postgres, skill-published charts rendered **read-only** on `/share-chart/<id>` — no Edit/History affordance, unlike charts shared from the signed-in UI.

This switches publishing to the backend's owner-tied, versioned store added in DEF-1411 (`POST /shared-charts`).

## Changes

- **Auth + endpoint**: POST via `api_request`, which carries the `FACTIQ_API_KEY` bearer token, to `{api}/shared-charts` instead of the blob route.
- **Ownership (the issue's open question)**: no backend or key→user lookup change was needed — `get_current_user` already resolves `fiq_` keys to the key's user (`auth.py`). The chart is owned by that user and is editable + version-restorable from the UI.
- **Response handling**: the backend returns `{shareId}` only; `shareUrl` is built from the web origin (`{web}/share-chart/{shareId}`), exactly as the frontend service does.
- **Payload unchanged** (`chart`/`chartData`/`question`/`source`/`metadata`/`transformStack`); the backend sanitizes (1200 rows / 40 cols / 400 chars) and enforces a ~2MB cap.
- Docs (`SKILL.md`, `references/chart-spec.md`) note the chart is owned/editable.

Legacy blob-published links keep resolving via the share page's dual-read fallback (untouched).

## E2E verification (against production `api.worlddb.ai`)

Published a chart via `factiq.py share-chart`, returning a working `shareUrl`. Then via the backend:

- `GET /shared-charts/<id>` **with** the API key → `isOwner: true`
- `GET /shared-charts/<id>` **anonymous** → `isOwner: false` (read-only, still resolves)
- `GET /shared-charts/<id>/versions` → v1 "Original", `editedBy: medhabasu09@gmail.com`
- Web `/share-chart/<id>` → HTTP 200

## Acceptance criteria

- [x] A skill-published chart is owned; its owner can edit it + see version history on `/share-chart/<id>`.
- [x] The skill still returns a working `shareUrl`.
- [x] Legacy blob-published links continue to resolve.

Closes DEF-1412. Related: DEF-1411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)