### PR TITLE
Add bespoke local HTML visualizations (build_viz.py)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "factiq",
       "source": "./",
-      "description": "Answer economic and financial data questions with real data from FactIQ — and publish shareable charts and reports."
+      "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, or build bespoke local HTML visualizations."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
-  "description": "Answer economic and financial data questions with real data from FactIQ — and publish shareable charts and reports.",
-  "version": "0.5.0",
+  "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, or build bespoke local HTML visualizations.",
+  "version": "0.6.0",
   "author": {
     "name": "Defog"
   }

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 A [Claude Code plugin](https://code.claude.com/docs/en/plugins) that lets
 Claude answer economic and financial data questions using FactIQ's data tools
 over HTTP — catalog search, read-only SQL, series lookup, market data,
-earnings-call search, and shareable chart publishing. Claude orchestrates the
-whole analysis itself; no codebase or database access is required, only a
-FactIQ account.
+earnings-call search, shareable chart/report publishing, and bespoke local
+HTML visualizations. Claude orchestrates the whole analysis itself; no codebase
+or database access is required, only a FactIQ account.
 
 ## Install
 
@@ -56,7 +56,13 @@ key is verified against the API and cached in `~/.factiq/config.json`
 - `commands/` — the `/factiq:*` slash commands
 - `scripts/factiq.py` — self-contained stdlib-only CLI for the FactIQ
   `/tools/*` API (Python 3.10+, no dependencies)
-- `references/` — SQL idioms, ChartSpec format, and dataset schema overview
+- `scripts/build_viz.py` — local-only tool to assemble fetched data into a
+  self-contained HTML viz and screenshot it headless for iteration. `assemble`
+  is stdlib-only; `render` installs Playwright + Chromium into
+  `~/.factiq/viz-venv` on first use (no effect on your system Python)
+- `assets/viz-shell.html` — starting-point shell for bespoke visualizations
+- `references/` — SQL idioms, ChartSpec/report formats, the bespoke-viz guide,
+  and dataset schema overview
 - `.claude-plugin/` — plugin + marketplace manifests
 
 ## Configuration

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,10 +7,11 @@ description: >
   customs, India MOSPI/RBI/trade, Singapore, IMF, World Bank), stock quotes
   and fundamentals, commodities/forex, and earnings-call intelligence. Use
   when the user asks about unemployment, inflation, GDP, trade flows, energy,
-  wages, markets, or wants a shareable economic chart or a full multi-section
-  research report. You orchestrate the whole analysis yourself — discover
-  series, query SQL, compute, then publish either a single chart or a
-  fully formed report as a share link.
+  wages, markets, or wants a shareable economic chart, a full multi-section
+  research report, or a bespoke custom visualization or dashboard saved as a
+  local HTML file. You orchestrate the whole analysis yourself — discover
+  series, query SQL, compute, then publish a single chart or a fully formed
+  report as a share link, or build a custom local HTML visualization.
 allowed-tools: Bash(python3:*), Bash(python:*), Read, Write
 ---
 
@@ -23,14 +24,19 @@ multi-section report. There is no server-side agent in this loop: you
 decompose the question, find the data, do the math with your own tokens, and
 author the output.
 
-Two output modes:
+Three output modes:
 
-- **Quick chart** (`share-chart`) — one focused chart. Default for questions
-  about a single metric or comparison.
+- **Quick chart** (`share-chart`) — one focused chart published to FactIQ as a
+  share link. Default for questions about a single metric or comparison.
 - **Detailed report** (`share-report`) — summary + sections of narrative and
   charts + methodology, rendered on FactIQ's share-report page exactly like
   the in-house agent's reports. For broad or analytical questions. See
   **Detailed reports** below.
+- **Bespoke local viz** (`build_viz.py`) — a self-contained HTML file you
+  author freely and save locally, not published to FactIQ. Use when the answer
+  needs something the ChartSpec can't express: a custom layout, a multi-panel
+  dashboard, a force/flow/chord diagram, a novel encoding, or fine-grained
+  visual control. See **Bespoke local visualizations** below.
 
 All access goes through the bundled CLI — no codebase or database access is
 needed:
@@ -113,12 +119,14 @@ in the environment first, then `api_key` in `~/.factiq/config.json`.
    for a server-side code interpreter; there is none in this loop.
 5. **Recent market data.** The DB lags for very recent market/price data —
    use `market` for current quotes, commodities, and FX.
-6. **Publish.** Quick-chart mode: write a ChartSpec JSON (see
+6. **Publish or build.** Quick-chart mode: write a ChartSpec JSON (see
    `references/chart-spec.md`) with wide-format data rows, then
-   `share-chart --spec chart.json`. Report mode: write a report JSON (see
-   `references/report-spec.md` and **Detailed reports** below), then
-   `share-report --report report.json`. Either way, return the `shareUrl`
-   to the user.
+   `share-chart --spec chart.json`; return the `shareUrl`. Report mode: write
+   a report JSON (see `references/report-spec.md` and **Detailed reports**
+   below), then `share-report --report report.json`; return the `shareUrl`.
+   Bespoke-viz mode: author an HTML file, `build_viz.py assemble` the
+   on-disk data into it, `build_viz.py render` to screenshot and iterate, then
+   give the user the local file path (see **Bespoke local visualizations**).
 
 ## Detailed reports
 
@@ -151,6 +159,38 @@ Ground rules:
 server response plus a `shareUrl` composed from your configured web origin.
 The report appears in your FactIQ history and can be forked by anyone who
 opens the share link.
+
+## Bespoke local visualizations
+
+When the answer wants something the published ChartSpec can't express — a
+custom layout, a dashboard of several panels, a force/flow/chord diagram, an
+annotated narrative, a novel encoding, or just fine visual control — build it
+yourself as a self-contained local HTML file. There is no spec and no fixed
+chart-type list: you author the HTML/JS (ECharts, D3, Canvas, SVG, WebGL),
+inject the data you already fetched, then render and iterate. Read
+`references/viz-guide.md` before starting — it covers technique selection, the
+data contract, and the legibility checklist.
+
+The tool is `scripts/build_viz.py` (local-only — it never calls the API):
+
+| Command | Purpose |
+|---|---|
+| `assemble --template T.html --data k=f.json … --out O.html [--open]` | Inject on-disk JSON into your HTML at the `__FACTIQ_DATA__` marker; write one portable, self-contained file. Stdlib only. |
+| `render O.html [--out P.png] [--width N] [--height N] [--full-page] [--selector CSS] [--wait MS]` | Screenshot the file in headless Chromium and report JS/console errors + failed asset loads. Installs Playwright + Chromium into `~/.factiq/viz-venv` on first run (uses `uv` if available, else a stdlib venv). |
+
+The loop that makes this work — **author → assemble → render → look → fix**:
+
+1. Fetch full data to disk as usual (`sql … --full --out /tmp/x.json`). Never
+   paste data rows into the HTML.
+2. Copy `assets/viz-shell.html`, add any CDN library you need, and author the
+   viz. Keep the `__FACTIQ_DATA__` marker — that is where the data lands.
+   After assembly the page exposes a `DATA` global; rows are at
+   `DATA.<key>.results`.
+3. `assemble` the self-contained file, then `render` it and **actually read
+   the screenshot**. `render` exits **5** when the page logged a JS error or a
+   failed request — that usually means a blank page; fix it before judging the
+   visual. One render pass is never enough; budget two or three.
+4. Hand the user the local file path; offer `--open` to open it in a browser.
 
 ## Context budget — sampled previews and `--out`
 
@@ -210,6 +250,9 @@ server-side, or raise `--max-rows`.
 - `references/report-spec.md` — report JSON format for `share-report`:
   sections, per-chart fields, sources/lineage authoring, limits, a worked
   example.
+- `references/viz-guide.md` — bespoke local HTML visualizations with
+  `build_viz.py`: the assemble/render loop, the `DATA` contract, technique
+  selection (ECharts/D3/Canvas/WebGL), a legibility checklist, starter recipes.
 - `references/schemas.md` — what lives in each schema. The `context`
   subcommand is the live, authoritative version; `search-datasets` /
   `describe` drill into individual datasets on demand.

--- a/assets/viz-shell.html
+++ b/assets/viz-shell.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<!--
+  FactIQ bespoke-viz shell. This is a starting point, not a framework — copy it,
+  then author whatever visualization the question calls for (ECharts, D3, Canvas,
+  SVG, WebGL). The only hard requirement is that the __FACTIQ_DATA__ marker below
+  survives, so build_viz.py can inject the data you fetched to disk.
+
+  After assembly a global `DATA` object is available, keyed by the names you pass
+  to `build_viz.py assemble --data <key>=<file.json>`. Each value is the full
+  factiq payload, so SQL/series rows live at DATA.<key>.results (columns at
+  DATA.<key>.columns). Load any library you need from a CDN in <head>.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FactIQ visualization</title>
+
+    <!-- Add CDN libraries here as needed, e.g.:
+         <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+         <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script> -->
+
+    <!-- Data, injected by build_viz.py. Leave this script tag in place. -->
+    <script id="factiq-data" type="application/json">
+__FACTIQ_DATA__
+    </script>
+
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #0b0c0e;
+        --fg: #e7e9ee;
+        --muted: #9aa0aa;
+        --line: #23262d;
+        --accent: #4f8cff;
+        --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+          Arial, sans-serif;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; height: 100%; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font);
+        -webkit-font-smoothing: antialiased;
+        line-height: 1.45;
+      }
+      #root { padding: 28px clamp(16px, 4vw, 48px); }
+      h1 { font-size: 22px; font-weight: 650; margin: 0 0 4px; letter-spacing: -0.01em; }
+      .sub { color: var(--muted); font-size: 14px; margin: 0 0 24px; }
+      .source { color: var(--muted); font-size: 12px; margin-top: 24px; border-top: 1px solid var(--line); padding-top: 12px; }
+    </style>
+  </head>
+
+  <body>
+    <div id="root">
+      <!-- Author the visualization here. Replace this placeholder. -->
+    </div>
+
+    <script>
+      // The single, library-agnostic entry point. `DATA` is whatever you
+      // injected; rows are typically at DATA.<key>.results.
+      const DATA = JSON.parse(
+        document.getElementById("factiq-data").textContent
+      );
+
+      // --- author your visualization below ---
+    </script>
+  </body>
+</html>

--- a/references/viz-guide.md
+++ b/references/viz-guide.md
@@ -1,0 +1,193 @@
+# Bespoke local visualizations
+
+This is the third FactIQ output mode, alongside `share-chart` and
+`share-report`. Those publish to factiq.com against fixed schemas; this one
+produces a **self-contained local HTML file** you author freely. There is no
+spec to satisfy and no fixed chart-type list — you write whatever HTML/JS the
+question calls for, render it, look at it, and fix what's wrong. That last
+loop is the method; everything else is plumbing.
+
+Use it when the answer wants something the ChartSpec can't express: a custom
+layout, a multi-panel dashboard, a force/flow/chord diagram, an annotated
+narrative, a novel encoding, an interactive cross-filtered view, or just
+fine-grained control over a chart's look.
+
+## The two commands
+
+`scripts/build_viz.py` is local-only (it never calls the FactIQ API):
+
+| Command | Purpose |
+|---|---|
+| `assemble --template T --data k=f.json … --out O.html [--open]` | Inject on-disk JSON into your HTML at the `__FACTIQ_DATA__` marker; write one portable file. Stdlib only. |
+| `render H.html [--out P.png] [--width] [--height] [--full-page] [--selector CSS] [--wait MS]` | Screenshot the file in headless Chromium and report JS/console errors + failed requests. Installs Playwright + Chromium into `~/.factiq/viz-venv` on first run. |
+
+`render` exits **5** when the page logged a JS error, an uncaught exception,
+or a failed asset request — treat a non-zero exit as "the viz is broken, read
+stderr," not "minor warning."
+
+## The workflow
+
+1. **Fetch full data to disk** with the existing CLI — never into your context:
+   ```bash
+   python3 scripts/factiq.py sql --schema bls --query "…" --full --out /tmp/jobs.json
+   ```
+2. **Copy the shell and author the viz.** Start from `assets/viz-shell.html`
+   (or write your own). Add any CDN `<script>` you need, then write the
+   visualization. Keep the `__FACTIQ_DATA__` marker — that is where the data
+   lands. Do **not** paste data rows into the HTML; that defeats the point.
+3. **Assemble** the self-contained file:
+   ```bash
+   python3 scripts/build_viz.py assemble \
+     --template my_viz.html --data jobs=/tmp/jobs.json --out /tmp/out.html
+   ```
+4. **Render and look.** Screenshot it, then actually read the image:
+   ```bash
+   python3 scripts/build_viz.py render /tmp/out.html --out /tmp/out.png
+   ```
+   If exit code is 5, read the errors on stderr and fix them first — a JS
+   error usually means a blank page. Then inspect the screenshot against the
+   legibility checklist below and iterate: edit → assemble → render → look,
+   until it is actually right. **One render pass is never enough** for bespoke
+   work; budget at least two or three.
+5. **Deliver.** Tell the user the file path; offer `assemble … --open` (or
+   `open /tmp/out.html`) to open it in their browser. The file is portable and
+   needs only internet for its CDN libraries.
+
+## The data contract
+
+After `assemble`, the page exposes one global:
+
+```js
+const DATA = JSON.parse(document.getElementById("factiq-data").textContent);
+```
+
+`DATA[key]` is the **full factiq payload** for the file you passed as
+`--data key=file.json`, exactly as written by `factiq.py … --out`:
+
+- SQL results: `DATA.key.results` is an array of **positional arrays** aligned
+  to `DATA.key.columns` (e.g. `["DC", 5.5, "2026-04-01"]`), *not* an array of
+  objects. Objectify them once at the top:
+  ```js
+  const cols = DATA.key.columns;
+  const rows = DATA.key.results.map((r) =>
+    Object.fromEntries(cols.map((c, i) => [c, r[i]]))
+  );
+  ```
+- `series` and `market` payloads keep their own shape — inspect the stub the
+  fetch printed (or `console.log(DATA.key)` once) before assuming a layout.
+
+Sort by your x value in JS before plotting — some endpoints return data
+reverse-chronological, which renders a backwards axis. Use `null` for gaps;
+don't drop rows.
+
+The assembler escapes the data so a literal `</script>`, `<`, `&`, or a
+Unicode line separator inside a value can't break out of the page —
+`JSON.parse` restores the original text, so values are unchanged.
+
+## Choosing the technique
+
+Match the tool to the shape of the visualization, not habit:
+
+- **ECharts** (`echarts@5`) — the path of least resistance for anything
+  chart-shaped: lines, bars, areas, scatter, candlestick, heatmaps, sankey,
+  graphs, radar. Great defaults, theming, dark mode, handles tens of
+  thousands of points. Reach for this first unless the layout is the point.
+- **D3** (`d3@7`) — when you need a custom layout or scale: force-directed
+  graphs, hierarchies (treemap/sunburst/pack), chord, arbitrary SVG with
+  hand-placed marks and annotations. More code, more control.
+- **Raw SVG / Canvas** — hand-drawn diagrams, small bespoke marks, or
+  high-cardinality scatter where SVG nodes get heavy (Canvas past ~10k marks).
+- **WebGL / Three.js / regl** — only past ~100k marks or for genuine 3D.
+- **Plotly** (`plotly@2`) — when you want scientific zoom/hover interactivity
+  out of the box and don't need custom layout.
+
+A "dashboard" is just a CSS grid of several of the above in one file — not a
+separate technique. Lay panels out with CSS grid/flex inside `#root`.
+
+## Legibility checklist (what to look for in the screenshot)
+
+- Axis/tick/legend labels don't overlap, clip, or run off the edge.
+- Scales make sense: no flat line because an outlier blew out the domain; log
+  scale where the data spans orders of magnitude; y-axis baseline honest.
+- Time axes are chronological and use real date formatting.
+- The title states the **finding with numbers**, not the topic — same bar as
+  `share-chart` (see `chart-spec.md`). Carry a source line at the bottom.
+- Color: enough contrast on the dark background; a sane categorical palette;
+  not red/green-only for accessibility.
+- Nothing is blank or half-rendered — if it is, check stderr for a JS error
+  and raise `--wait` if an animation/CDN load needed more time.
+- Multi-panel: panels align, share scales where comparison is intended, and
+  each panel is individually readable at the chosen viewport size.
+
+## Starter recipes
+
+These are starting points to adapt, not templates to fill in. Each assumes
+the shell's `DATA` global and a CDN `<script>` added in `<head>`.
+
+### ECharts line chart
+```html
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+```
+```js
+const cols = DATA.jobs.columns;
+const rows = DATA.jobs.results
+  .map((r) => Object.fromEntries(cols.map((c, i) => [c, r[i]])))
+  .sort((a, b) => String(a.date).localeCompare(String(b.date)));
+const root = document.getElementById("root");
+const el = document.createElement("div");
+el.style.cssText = "width:100%;height:480px";
+root.appendChild(el);
+echarts.init(el, "dark").setOption({
+  backgroundColor: "transparent",
+  title: { text: "US payrolls grew 2.1% in 2024" },
+  tooltip: { trigger: "axis" },
+  xAxis: { type: "category", data: rows.map((r) => r.date) },
+  yAxis: { type: "value" },
+  series: [{ type: "line", smooth: true, data: rows.map((r) => r.value) }],
+});
+```
+
+### D3 force-directed graph (custom layout)
+```html
+<script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+```
+```js
+// DATA.edges columns: [source, target, weight]; objectify, then build nodes.
+const ec = DATA.edges.columns;
+const links = DATA.edges.results.map((r) =>
+  Object.fromEntries(ec.map((c, i) => [c, r[i]]))
+);
+const ids = [...new Set(links.flatMap((l) => [l.source, l.target]))];
+const nodes = ids.map((id) => ({ id }));
+const W = 1200, H = 760;
+const svg = d3.select("#root").append("svg").attr("viewBox", `0 0 ${W} ${H}`);
+const sim = d3
+  .forceSimulation(nodes)
+  .force("link", d3.forceLink(links).id((d) => d.id).distance(80))
+  .force("charge", d3.forceManyBody().strength(-220))
+  .force("center", d3.forceCenter(W / 2, H / 2));
+const link = svg.append("g").attr("stroke", "#3a3f4b").selectAll("line")
+  .data(links).join("line").attr("stroke-width", (d) => Math.sqrt(d.weight));
+const node = svg.append("g").selectAll("circle")
+  .data(nodes).join("circle").attr("r", 6).attr("fill", "#4f8cff");
+sim.on("tick", () => {
+  link.attr("x1", (d) => d.source.x).attr("y1", (d) => d.source.y)
+      .attr("x2", (d) => d.target.x).attr("y2", (d) => d.target.y);
+  node.attr("cx", (d) => d.x).attr("cy", (d) => d.y);
+});
+```
+Force layouts settle over time — give `render` a larger `--wait` (e.g.
+`--wait 2500`) so the screenshot catches the relaxed graph, or call
+`sim.tick()` in a loop and render statically.
+
+### Dashboard grid (multiple panels)
+```css
+#root { display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px; }
+.panel { min-height: 360px; }
+.kpis { grid-column: 1 / -1; display: flex; gap: 24px; }
+.kpi { font-size: 13px; color: var(--muted); }
+.kpi b { display: block; font-size: 30px; color: var(--fg); }
+```
+Append a `.panel` div per chart, init one ECharts instance into each, and put
+headline numbers in a full-width `.kpis` row on top. Render with a taller
+viewport (`--height 1200 --full-page`) and check every panel is readable.

--- a/scripts/build_viz.py
+++ b/scripts/build_viz.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""FactIQ bespoke-viz builder — assemble data into a self-contained HTML file
+and render it headless so you can see (and fix) your own visualization.
+
+This is the local-output counterpart to factiq.py's share-chart/share-report:
+it never talks to the FactIQ API. You author an HTML file (any technique —
+ECharts, D3, Canvas, SVG, WebGL), this script injects the data you already
+fetched to disk, then screenshots the result so the render → look → fix loop
+can run without pulling thousands of data rows back into your context.
+
+Two subcommands:
+
+  assemble  — inject on-disk JSON into an HTML template at the data marker,
+              producing one portable, self-contained .html. Stdlib only.
+  render    — open an HTML file in headless Chromium, write a PNG, and report
+              any JS/console errors and failed requests. Needs Playwright;
+              installs the package and Chromium on first run.
+
+Data contract: the template must contain the marker token __FACTIQ_DATA__
+inside a JSON script tag (see assets/viz-shell.html). After assembly the page
+exposes a global `DATA` object keyed by the names you passed to --data; each
+value is the full factiq payload, so result rows live at DATA.<key>.results.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import webbrowser
+
+DATA_MARKER = "__FACTIQ_DATA__"
+
+
+def fail(message: str, code: int = 1) -> None:
+    print(json.dumps({"error": message}), file=sys.stderr)
+    sys.exit(code)
+
+
+def _row_count(value: object) -> int | None:
+    """Best-effort count of data rows for the assemble stub.
+
+    factiq.py --out files are payload objects with the rows under "results";
+    a bare list counts directly. Anything else has no meaningful row count.
+    """
+    if isinstance(value, dict) and isinstance(value.get("results"), list):
+        return len(value["results"])
+    if isinstance(value, list):
+        return len(value)
+    return None
+
+
+def _escape_for_html(text: str) -> str:
+    """Make a JSON string safe to embed inside an HTML <script> element.
+
+    JSON.parse decodes these escapes back to the original characters, so the
+    data is unchanged — this only prevents a literal </script> (or a U+2028 /
+    U+2029 line separator) in the data from breaking out of the script tag or
+    the surrounding JS.
+    """
+    # JSON.parse decodes these \\uXXXX escapes, so the data is unchanged.
+    return text.translate(
+        {
+            0x3C: "\\u003c",  # <
+            0x3E: "\\u003e",  # >
+            0x26: "\\u0026",  # &
+            0x2028: "\\u2028",  # line separator
+            0x2029: "\\u2029",  # paragraph separator
+        }
+    )
+
+
+def cmd_assemble(args: argparse.Namespace) -> None:
+    try:
+        with open(args.template) as f:
+            html = f.read()
+    except OSError as exc:
+        fail(f"Cannot read template {args.template}: {exc}")
+
+    if DATA_MARKER not in html:
+        fail(
+            f"Template {args.template} has no {DATA_MARKER} marker. Author the "
+            "HTML on assets/viz-shell.html (or add a JSON script tag containing "
+            f"{DATA_MARKER}) so the data has somewhere to land."
+        )
+
+    data: dict = {}
+    counts: dict = {}
+    for pair in args.data or []:
+        if "=" not in pair:
+            fail(f"--data expects key=path, got {pair!r}")
+        key, path = pair.split("=", 1)
+        key = key.strip()
+        if not key:
+            fail(f"--data entry {pair!r} has an empty key")
+        if key in data:
+            fail(f"--data key {key!r} given twice")
+        try:
+            with open(path) as f:
+                value = json.load(f)
+        except OSError as exc:
+            fail(f"Cannot read data file {path}: {exc}")
+        except json.JSONDecodeError as exc:
+            fail(f"Data file {path} is not valid JSON: {exc}")
+        data[key] = value
+        rc = _row_count(value)
+        if rc is not None:
+            counts[key] = rc
+
+    payload = _escape_for_html(json.dumps(data))
+    html = html.replace(DATA_MARKER, payload)
+
+    out = os.path.abspath(args.out)
+    try:
+        with open(out, "w") as f:
+            f.write(html)
+    except OSError as exc:
+        fail(f"Cannot write {out}: {exc}")
+
+    stub = {"out": out, "bytes": len(html.encode()), "keys": list(data.keys())}
+    if counts:
+        stub["rows"] = counts
+    print(json.dumps(stub, indent=2))
+
+    if args.open:
+        webbrowser.open(f"file://{out}")
+
+
+VENV_DIR = os.path.expanduser("~/.factiq/viz-venv")
+
+
+def _venv_python(venv_dir: str) -> str:
+    if os.name == "nt":
+        return os.path.join(venv_dir, "Scripts", "python.exe")
+    return os.path.join(venv_dir, "bin", "python")
+
+
+def _venv_has_playwright(venv_py: str) -> bool:
+    return (
+        subprocess.run(
+            [venv_py, "-c", "import playwright.sync_api"],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def _ensure_render_env():
+    """Return sync_playwright, or re-exec this script under a dedicated venv.
+
+    The interpreter that launched us may be externally managed (Homebrew, uv,
+    distro python) where `pip install` is refused. Rather than touch it, we
+    keep a private venv at ~/.factiq/viz-venv, install Playwright there, and
+    re-exec the same command under that venv's python. Chromium itself is
+    installed lazily by the launch fallback in cmd_render, now running under
+    the venv.
+    """
+    try:
+        from playwright.sync_api import sync_playwright  # noqa: F401
+
+        return sync_playwright
+    except ImportError:
+        pass
+
+    if os.environ.get("FACTIQ_VIZ_REEXEC"):
+        fail("Playwright is unavailable even after venv setup.", 6)
+
+    venv_py = _venv_python(VENV_DIR)
+    # Prefer uv when present: the interpreter that launched us is often a
+    # uv-managed build with no ensurepip, so stdlib `venv --with-pip` aborts.
+    # uv creates the venv and installs into it without needing pip bootstrapped.
+    uv = shutil.which("uv")
+    if not os.path.exists(venv_py):
+        print(
+            "Creating a Playwright virtualenv (first run, one time)…",
+            file=sys.stderr,
+            flush=True,
+        )
+        try:
+            if uv:
+                subprocess.run([uv, "venv", VENV_DIR], check=True)
+            else:
+                import venv
+
+                venv.EnvBuilder(with_pip=True).create(VENV_DIR)
+        except (subprocess.CalledProcessError, OSError) as exc:
+            fail(
+                f"Failed to create a virtualenv at {VENV_DIR}: {exc}. Install uv "
+                "(https://docs.astral.sh/uv/) or a python that bundles pip.",
+                6,
+            )
+    if not _venv_has_playwright(venv_py):
+        print(
+            "Installing Playwright into the virtualenv (first run, one time)…",
+            file=sys.stderr,
+            flush=True,
+        )
+        cmd = (
+            [uv, "pip", "install", "--python", venv_py, "--quiet", "playwright"]
+            if uv
+            else [venv_py, "-m", "pip", "install", "--quiet", "playwright"]
+        )
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as exc:
+            fail(f"Failed to install the playwright package into {VENV_DIR}: {exc}", 6)
+
+    env = dict(os.environ, FACTIQ_VIZ_REEXEC="1")
+    os.execve(venv_py, [venv_py, os.path.abspath(__file__), *sys.argv[1:]], env)
+
+
+def _install_chromium() -> None:
+    print(
+        "Installing Chromium for Playwright (first run, one time)…",
+        file=sys.stderr,
+        flush=True,
+    )
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "playwright", "install", "chromium"], check=True
+        )
+    except subprocess.CalledProcessError as exc:
+        fail(f"Failed to install Chromium: {exc}", 6)
+
+
+def cmd_render(args: argparse.Namespace) -> None:
+    html_path = os.path.abspath(args.html)
+    if not os.path.exists(html_path):
+        fail(f"No such HTML file: {html_path}")
+    out = os.path.abspath(args.out) if args.out else os.path.splitext(html_path)[0] + ".png"
+
+    sync_playwright = _ensure_render_env()
+
+    errors: list[str] = []
+    with sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except Exception as exc:  # missing browser binary on first run
+            msg = str(exc).lower()
+            if "install" in msg or "executable doesn't exist" in msg:
+                _install_chromium()
+                browser = p.chromium.launch()
+            else:
+                raise
+        try:
+            page = browser.new_page(
+                viewport={"width": args.width, "height": args.height},
+                device_scale_factor=args.scale,
+            )
+            # A console.error, an uncaught exception, or a failed asset load
+            # (e.g. a CDN library that didn't reach the page) all leave a
+            # broken or blank visualization — collect each so a silent failure
+            # surfaces instead of producing an innocent-looking screenshot.
+            page.on(
+                "console",
+                lambda m: errors.append(f"console.{m.type}: {m.text}")
+                if m.type == "error"
+                else None,
+            )
+            page.on("pageerror", lambda e: errors.append(f"pageerror: {e}"))
+            page.on(
+                "requestfailed",
+                lambda r: errors.append(
+                    f"requestfailed: {r.url} ({r.failure})"
+                ),
+            )
+            page.goto(f"file://{html_path}", wait_until="load")
+            try:
+                page.wait_for_load_state("networkidle", timeout=10000)
+            except Exception:
+                # Some pages (animations, polling) never go idle — not fatal.
+                pass
+            if args.wait:
+                page.wait_for_timeout(args.wait)
+            target = page.locator(args.selector) if args.selector else page
+            target.screenshot(path=out, **({} if args.selector else {"full_page": args.full_page}))
+        finally:
+            browser.close()
+
+    stub = {"out": out, "width": args.width, "height": args.height}
+    print(json.dumps(stub, indent=2))
+    if errors:
+        print(
+            "\nWARNING: the page reported "
+            f"{len(errors)} error(s) — the screenshot may be broken or blank:",
+            file=sys.stderr,
+        )
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        sys.exit(5)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="build_viz.py", description="Assemble and render bespoke local visualizations"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser(
+        "assemble",
+        help="Inject on-disk JSON into an HTML template; write a self-contained file",
+    )
+    p.add_argument("--template", required=True, help="HTML you authored (with the data marker)")
+    p.add_argument(
+        "--data",
+        nargs="+",
+        metavar="KEY=PATH",
+        help="One or more key=path pairs; each file's JSON lands at DATA.<key>",
+    )
+    p.add_argument("--out", required=True, help="Output HTML path")
+    p.add_argument("--open", action="store_true", help="Open the result in the browser")
+    p.set_defaults(func=cmd_assemble)
+
+    p = sub.add_parser(
+        "render",
+        help="Screenshot an HTML file headless and report JS/console errors",
+    )
+    p.add_argument("html", help="Path to the HTML file to render")
+    p.add_argument("--out", help="PNG output path (default: alongside the HTML)")
+    p.add_argument("--width", type=int, default=1280, help="Viewport width (default 1280)")
+    p.add_argument("--height", type=int, default=900, help="Viewport height (default 900)")
+    p.add_argument("--scale", type=float, default=2.0, help="Device scale factor (default 2)")
+    p.add_argument("--full-page", action="store_true", help="Capture the full scrollable page")
+    p.add_argument("--selector", help="Screenshot only the element matching this CSS selector")
+    p.add_argument(
+        "--wait",
+        type=int,
+        default=600,
+        help="Extra wait in ms after load for late renders/animations (default 600)",
+    )
+    p.set_defaults(func=cmd_render)
+
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a third FactIQ output mode beside `share-chart` and `share-report`: a **self-contained local HTML visualization** you author freely and save locally, rather than publishing to factiq.com against a fixed schema. Use it when the answer needs something the ChartSpec can't express — a custom layout, a multi-panel dashboard, a force/flow/chord diagram, a novel encoding, or fine visual control.

The data layer is unchanged — `factiq.py … --out file.json` already lands full result sets on disk. The new piece is purely render-to-local-HTML, which needs no server round-trip; that's what makes the output genuinely bespoke (no spec, no fixed chart-type list).

## What's new

- **`scripts/build_viz.py`** (local-only, never calls the API):
  - `assemble` (stdlib): injects on-disk JSON into an HTML template at the `__FACTIQ_DATA__` marker → one portable file. Data goes disk→file, never through the model's context. XSS-safe escaping so a literal `</script>` in a value can't break out.
  - `render`: headless-Chromium screenshot that reports JS/console errors and failed asset loads (exit 5), so a blank page can't pass as success. First run builds a private venv at `~/.factiq/viz-venv` (uses `uv` when present, else stdlib `venv`) and installs Playwright + Chromium — the system Python is left untouched.
- **`assets/viz-shell.html`** — a near-empty, library-agnostic starting shell (`#root` + the data marker). Not a dashboard template; you bring whatever technique fits.
- **`references/viz-guide.md`** — technique selection (ECharts → D3 → Canvas → WebGL), the `DATA` contract, the author → render → look → fix loop, a legibility checklist, and starter recipes.
- **SKILL.md / README / manifests** — document the mode, wire it into the workflow and trigger description; version bumped `0.5.0 → 0.6.0`.

## Verification

Tested end-to-end against live FactIQ data: queried BLS LAUS state unemployment rates, authored a bespoke D3 ranked-lollipop viz (color + length dual encoding), assembled, and rendered headless — clean output, 52 jurisdictions, no label collisions. Also confirmed: the venv/Chromium bootstrap on a uv-managed Python, error detection firing on a real uncaught exception and a failed CDN load, and the `</script>` escaping round-trip. The proof run also surfaced a doc bug (SQL `results` are positional arrays, not objects), fixed in the guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)