### PR TITLE
Fix build_viz doc gaps and make --data forgiving (#15)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, or build bespoke local HTML visualizations.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "Defog"
   }

--- a/SKILL.md
+++ b/SKILL.md
@@ -175,7 +175,7 @@ The tool is `scripts/build_viz.py` (local-only — it never calls the API):
 
 | Command | Purpose |
 |---|---|
-| `assemble --template T.html --data k=f.json … --out O.html [--open]` | Inject on-disk JSON into your HTML at the `__FACTIQ_DATA__` marker; write one portable, self-contained file. Stdlib only. |
+| `assemble --template T.html --data k1=f1.json k2=f2.json … --out O.html [--open]` | Inject on-disk JSON into your HTML at the `__FACTIQ_DATA__` marker; write one portable, self-contained file. Stdlib only. List **all** key=path pairs after the one `--data` flag. |
 | `render O.html [--out P.png] [--width N] [--height N] [--full-page] [--selector CSS] [--wait MS]` | Screenshot the file in headless Chromium and report JS/console errors + failed asset loads. Installs Playwright + Chromium into `~/.factiq/viz-venv` on first run (uses `uv` if available, else a stdlib venv). |
 
 The loop that makes this work — **author → assemble → render → look → fix**:
@@ -183,9 +183,10 @@ The loop that makes this work — **author → assemble → render → look → 
 1. Fetch full data to disk as usual (`sql … --full --out /tmp/x.json`). Never
    paste data rows into the HTML.
 2. Copy `assets/viz-shell.html`, add any CDN library you need, and author the
-   viz. Keep the `__FACTIQ_DATA__` marker — that is where the data lands.
-   After assembly the page exposes a `DATA` global; rows are at
-   `DATA.<key>.results`.
+   viz. Keep the `__FACTIQ_DATA__` marker inside its
+   `<script id="factiq-data" type="application/json">` tag — that exact element
+   is where the data lands and how the page reads it back. After assembly the
+   page exposes a `DATA` global; rows are at `DATA.<key>.results`.
 3. `assemble` the self-contained file, then `render` it and **actually read
    the screenshot**. `render` exits **5** when the page logged a JS error or a
    failed request — that usually means a blank page; fix it before judging the

--- a/references/viz-guide.md
+++ b/references/viz-guide.md
@@ -18,7 +18,7 @@ fine-grained control over a chart's look.
 
 | Command | Purpose |
 |---|---|
-| `assemble --template T --data k=f.json … --out O.html [--open]` | Inject on-disk JSON into your HTML at the `__FACTIQ_DATA__` marker; write one portable file. Stdlib only. |
+| `assemble --template T --data k1=f1.json k2=f2.json … --out O.html [--open]` | Inject on-disk JSON into your HTML at the `__FACTIQ_DATA__` marker; write one portable file. Stdlib only. Pass **all** key=path pairs after the single `--data` flag (or repeat the flag — both work). |
 | `render H.html [--out P.png] [--width] [--height] [--full-page] [--selector CSS] [--wait MS]` | Screenshot the file in headless Chromium and report JS/console errors + failed requests. Installs Playwright + Chromium into `~/.factiq/viz-venv` on first run. |
 
 `render` exits **5** when the page logged a JS error, an uncaught exception,
@@ -35,11 +35,18 @@ stderr," not "minor warning."
    (or write your own). Add any CDN `<script>` you need, then write the
    visualization. Keep the `__FACTIQ_DATA__` marker — that is where the data
    lands. Do **not** paste data rows into the HTML; that defeats the point.
-3. **Assemble** the self-contained file:
+3. **Assemble** the self-contained file. Bespoke vizzes usually combine
+   several series, so list every file after one `--data` flag:
    ```bash
    python3 scripts/build_viz.py assemble \
-     --template my_viz.html --data jobs=/tmp/jobs.json --out /tmp/out.html
+     --template my_viz.html \
+     --data jobs=/tmp/jobs.json gdp=/tmp/gdp.json vac=/tmp/vac.json \
+     --out /tmp/out.html
    ```
+   `--data` takes **all** the `key=path` pairs that follow it; don't repeat the
+   flag once per file expecting each to stick. (Repeating it does now work too,
+   but the single-flag form above is canonical.) Each file lands at its key, so
+   above you get `DATA.jobs`, `DATA.gdp`, and `DATA.vac`.
 4. **Render and look.** Screenshot it, then actually read the image:
    ```bash
    python3 scripts/build_viz.py render /tmp/out.html --out /tmp/out.png
@@ -49,11 +56,35 @@ stderr," not "minor warning."
    legibility checklist below and iterate: edit → assemble → render → look,
    until it is actually right. **One render pass is never enough** for bespoke
    work; budget at least two or three.
+
+   **Caveat for tall pages:** headless Chromium lazy-paints off-screen
+   canvases, so on a long page a `--full-page` shot can show every
+   below-the-fold ECharts/Canvas/WebGL chart as blank even though it renders
+   fine in a real browser. Don't conclude those charts are broken — verify a
+   suspect one with `render … --selector "#chart-id"`, which scrolls that
+   element into view before shooting it.
 5. **Deliver.** Tell the user the file path; offer `assemble … --open` (or
    `open /tmp/out.html`) to open it in their browser. The file is portable and
    needs only internet for its CDN libraries.
 
 ## The data contract
+
+The `__FACTIQ_DATA__` marker only works inside this exact element:
+
+```html
+<script id="factiq-data" type="application/json">
+__FACTIQ_DATA__
+</script>
+```
+
+`assemble` substitutes the marker wherever it sits, but the page reads the
+data back by `id`, so the marker **must** live inside a
+`<script id="factiq-data" type="application/json">` tag. If you author a
+template from scratch, reproduce that element verbatim. Drop the bare marker
+anywhere else — an HTML comment, a `<div>`, the wrong id — and
+`getElementById("factiq-data")` returns `null`, giving
+`Cannot read properties of null (reading 'textContent')` and a blank page.
+(Starting from `assets/viz-shell.html` gives you the element for free.)
 
 After `assemble`, the page exposes one global:
 
@@ -113,9 +144,15 @@ separate technique. Lay panels out with CSS grid/flex inside `#root`.
 - The title states the **finding with numbers**, not the topic — same bar as
   `share-chart` (see `chart-spec.md`). Carry a source line at the bottom.
 - Color: enough contrast on the dark background; a sane categorical palette;
-  not red/green-only for accessibility.
+  not red/green-only for accessibility. In ECharts the legend swatch takes its
+  color from `series.itemStyle.color`, not `series.lineStyle.color` — a line
+  with a custom `lineStyle.color` but no `itemStyle.color` gets a mismatched
+  default-palette legend dot. Set both (or just `color` on the series).
 - Nothing is blank or half-rendered — if it is, check stderr for a JS error
-  and raise `--wait` if an animation/CDN load needed more time.
+  and raise `--wait` if an animation/CDN load needed more time. But a blank
+  canvas chart *below the fold* in a `--full-page` shot is usually just
+  headless lazy-painting, not a real failure — re-check it with `--selector`
+  before debugging (see the render caveat above).
 - Multi-panel: panels align, share scales where comparison is intended, and
   each panel is individually readable at the chosen viewport size.
 

--- a/scripts/build_viz.py
+++ b/scripts/build_viz.py
@@ -88,7 +88,12 @@ def cmd_assemble(args: argparse.Namespace) -> None:
 
     data: dict = {}
     counts: dict = {}
-    for pair in args.data or []:
+    # --data is action="append" over nargs="+", so args.data is a list of
+    # lists: both `--data a=x b=y` (one flag, many pairs) and `--data a=x
+    # --data b=y` (repeated flag) end up here. Flatten so neither form
+    # silently drops pairs.
+    pairs = [pair for group in (args.data or []) for pair in group]
+    for pair in pairs:
         if "=" not in pair:
             fail(f"--data expects key=path, got {pair!r}")
         key, path = pair.split("=", 1)
@@ -306,8 +311,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--data",
         nargs="+",
+        action="append",
         metavar="KEY=PATH",
-        help="One or more key=path pairs; each file's JSON lands at DATA.<key>",
+        help="One or more key=path pairs; each file's JSON lands at DATA.<key>. "
+        "Pass several after one flag (--data a=x b=y) or repeat the flag "
+        "(--data a=x --data b=y); both work.",
     )
     p.add_argument("--out", required=True, help="Output HTML path")
     p.add_argument("--open", action="store_true", help="Open the result in the browser")


### PR DESCRIPTION
Fixes #15.

Three doc gaps in bespoke-viz mode each cost an assemble→render→inspect→debug cycle, plus one tool footgun. Addresses all of them:

### Code (`scripts/build_viz.py`)
- **`--data` now accepts both forms.** It was `nargs="+"` with the default store action, so repeating the flag (`--data a=x --data b=y`) silently kept only the *last* pair — every chart but the last then threw `Cannot read properties of undefined (reading 'columns')` at runtime. Changed to `action="append"` over `nargs="+"` and flatten in `cmd_assemble`, so `--data a=x b=y` (single flag) *and* `--data a=x --data b=y` (repeated flag) both keep every pair. Duplicate-key detection still fires.

### Docs (`references/viz-guide.md`, `SKILL.md`)
1. **Multi-file `--data`** — the example and table now show all pairs after one flag (`--data jobs=… gdp=… vac=…`), the common case for bespoke vizzes.
2. **Marker placement** — the data contract now states the `__FACTIQ_DATA__` marker only works inside `<script id="factiq-data" type="application/json">`, with the `null`/blank-page failure you get otherwise. Reinforced in SKILL.md.
3. **`--full-page` off-screen canvases** — added a render caveat: headless Chromium lazy-paints below-the-fold canvas charts, so verify a suspect one with `--selector` rather than concluding it's broken. Also reinforced in the legibility checklist.
4. **Minor:** ECharts legend swatch color comes from `series.itemStyle.color`, not `lineStyle.color`.

Bumped plugin to `0.6.1`. Script compiles clean; both `--data` forms and the duplicate-key error verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVTsABT9ZPahfH7CM5VFFu