### PR TITLE
Default the MCP server to api.factiq.com (0.7.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, or build bespoke local HTML visualizations.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "Defog"
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "factiq": {
       "type": "http",
-      "url": "${FACTIQ_MCP_URL:-https://api.worlddb.ai/mcp}"
+      "url": "${FACTIQ_MCP_URL:-https://api.factiq.com/mcp}"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ git clone git@github.com:defog-ai/factiq-claude-code-plugin.git ~/.claude/skills
 
 The skill auto-invokes the same way. As a plain skill the bundled `.mcp.json`
 is not loaded automatically — add the MCP server yourself with
-`claude mcp add --transport http factiq https://api.worlddb.ai/mcp`, then
+`claude mcp add --transport http factiq https://api.factiq.com/mcp`, then
 authorize it with `/mcp`.
 </details>
 
@@ -73,7 +73,7 @@ failures too.
 
 ## Configuration
 
-The MCP server defaults to `https://api.worlddb.ai/mcp`. For local development
+The MCP server defaults to `https://api.factiq.com/mcp`. For local development
 against a local backend, set `FACTIQ_MCP_URL=http://localhost:8000/mcp` before
 starting Claude Code (it expands in `.mcp.json`).
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -75,7 +75,7 @@ same FactIQ login: email, Google, or passkey). Nothing to copy or paste, and no
 separate key for publishing — the same connection authorizes `share_chart` /
 `share_report`.
 
-**Local development.** The MCP URL defaults to `https://api.worlddb.ai/mcp`;
+**Local development.** The MCP URL defaults to `https://api.factiq.com/mcp`;
 override it for a local backend by setting
 `FACTIQ_MCP_URL=http://localhost:8000/mcp` before Claude Code starts (it expands
 in `.mcp.json`).


### PR DESCRIPTION
## Problem

The backend migrated from `worlddb.ai` to `factiq.com`, but the bundled FactIQ MCP server in v0.7.0 still defaults to `https://api.worlddb.ai/mcp`. On a fresh install the OAuth flow fails:

```
Protected resource https://api.factiq.com/mcp does not match expected https://api.worlddb.ai/mcp (or origin)
```

The server's protected-resource metadata advertises `api.factiq.com/mcp`, which doesn't match the requested `worlddb.ai` origin, so the SDK rejects auth. Every fresh install / new teammate hits this.

## Fix

Point the default at `https://api.factiq.com/mcp` in the three places that shipped the old host:

- `.mcp.json` — the `${FACTIQ_MCP_URL:-…}` default the plugin actually uses
- `README.md` — manual `claude mcp add` instructions + documented default
- `SKILL.md` — local-development note

The `FACTIQ_MCP_URL` env override is unchanged, so local-backend development (`http://localhost:8000/mcp`) still works. Version bumped 0.7.0 → 0.7.1.

## Verification

`https://api.factiq.com/mcp` is live (returns 405 to a GET, i.e. POST-only MCP endpoint as expected). No `worlddb.ai` references remain in the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)