### PR TITLE
Add Codex support; dual Claude Code + Codex plugin

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "0.8.0",
   "author": {
     "name": "Defog"
-  }
+  },
+  "skills": "../",
+  "mcpServers": "../.mcp.json"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# FactIQ Plugin
+
+This plugin gives you access to FactIQ's economic and financial data tools via
+MCP. Read `SKILL.md` for the full workflow, tool reference, output modes, and
+reference docs.
+
+## Quick start
+
+1. Authorize the MCP server: run `codex mcp login factiq` and complete the
+   browser sign-in (email, Google, or passkey).
+2. Ask any economic or financial data question — the skill activates
+   automatically.
+
+## What you can do
+
+- **Quick chart** — one focused chart published to FactIQ as a share link.
+- **Detailed report** — multi-section research report with narrative + charts.
+- **Bespoke local viz** — a self-contained HTML file for custom dashboards,
+  force graphs, chord diagrams, or anything the standard chart spec can't
+  express.
+
+All data discovery, fetching, and publishing goes through the FactIQ MCP tools.
+The only local script is `scripts/build_viz.py` for bespoke HTML visualizations.
+
+## Reference docs
+
+- `references/sql-guide.md` — table structure, query idioms, pitfalls
+- `references/chart-spec.md` — ChartSpec format for `share_chart`
+- `references/report-spec.md` — report JSON format for `share_report`
+- `references/viz-guide.md` — bespoke local HTML visualizations
+- `references/schemas.md` — what lives in each data schema

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
-# FactIQ Claude Code Plugin
+# FactIQ Plugin
 
-A [Claude Code plugin](https://code.claude.com/docs/en/plugins) that lets
-Claude answer economic and financial data questions using FactIQ's data —
-catalog search, read-only SQL, series lookup, market data, earnings-call
-search — and publish the result as a shareable FactIQ chart or report, or as a
-bespoke local HTML visualization. Claude orchestrates the whole analysis
-itself; no codebase or database access is required, only a FactIQ account.
+A plugin for [Claude Code](https://code.claude.com/docs/en/plugins) and
+[Codex](https://github.com/openai/codex) that lets your coding agent answer
+economic and financial data questions using FactIQ's data — catalog search,
+read-only SQL, series lookup, market data, earnings-call search — and publish
+the result as a shareable FactIQ chart or report, or as a bespoke local HTML
+visualization. The agent orchestrates the whole analysis itself; no codebase or
+database access is required, only a FactIQ account.
 
 Everything runs through the **FactIQ MCP server** (bundled in `.mcp.json`),
-which Claude Code talks to natively over a single OAuth connection — discovery,
-fetching, and publishing alike. There is no API key to manage. The one bundled
-script, `build_viz.py`, is local-only (it builds HTML visualizations and never
-touches the network).
+which both Claude Code and Codex talk to natively over a single OAuth
+connection — discovery, fetching, and publishing alike. There is no API key to
+manage. The one bundled script, `build_viz.py`, is local-only (it builds HTML
+visualizations and never touches the network).
 
 ## Install
 
-Inside Claude Code:
+### Claude Code
 
 ```
 /plugin marketplace add defog-ai/factiq-claude-code-plugin
@@ -30,38 +31,66 @@ data questions), the bundled FactIQ MCP server, and the `/factiq:ask` command:
 | `/factiq:ask <question>` | Run a full analysis and get a shareable chart or report |
 
 Then run **`/mcp`** once, pick **factiq**, and complete the browser-based
-Connect flow to authorize the tools (see below). That single connection covers
-both fetching data and publishing.
+Connect flow to authorize the tools (see below).
 
-<details>
-<summary>Alternative: install as a plain skill (no slash command / no MCP)</summary>
+### Codex
 
 ```bash
-git clone git@github.com:defog-ai/factiq-claude-code-plugin.git ~/.claude/skills/factiq
+git clone https://github.com/defog-ai/factiq-claude-code-plugin.git ~/.codex/plugins/factiq
 ```
 
-The skill auto-invokes the same way. As a plain skill the bundled `.mcp.json`
-is not loaded automatically — add the MCP server yourself with
-`claude mcp add --transport http factiq https://api.factiq.com/mcp`, then
-authorize it with `/mcp`.
+Then authorize the MCP server:
+
+```bash
+codex mcp login factiq
+```
+
+Complete the browser sign-in (the same FactIQ login: email, Google, or
+passkey). The skill auto-invokes for economic/financial data questions.
+
+<details>
+<summary>Alternative: install as a standalone MCP server (no plugin)</summary>
+
+Add the MCP server directly to your Codex config (`~/.codex/config.toml`):
+
+```toml
+[mcp_servers.factiq]
+url = "https://api.factiq.com/mcp"
+```
+
+Then `codex mcp login factiq`. The skill won't auto-invoke without the plugin,
+but the MCP tools are available for manual use.
+
+For Claude Code without the plugin:
+
+```bash
+claude mcp add --transport http factiq https://api.factiq.com/mcp
+```
+
+Then authorize with `/mcp`.
 </details>
 
 ## Authentication
 
-One credential, no keys. The tools live on the FactIQ MCP server; Claude Code
-authorizes them over OAuth. Run **`/mcp`**, pick **factiq**, and complete the
-browser sign-in (the same FactIQ login: email, Google, or passkey). Claude Code
-stores and refreshes the token; there is nothing to paste. If the
-`mcp__plugin_factiq_*` tools ever return an auth error, re-run `/mcp` to
-reconnect — the same connection authorizes publishing, so this fixes publish
-failures too.
+One credential, no keys. The tools live on the FactIQ MCP server, authorized
+over OAuth:
+
+- **Claude Code**: run **`/mcp`**, pick **factiq**, and complete the browser
+  sign-in.
+- **Codex**: run **`codex mcp login factiq`** and complete the browser sign-in.
+
+The same FactIQ login works everywhere (email, Google, or passkey). The agent
+stores and refreshes the token; there is nothing to paste. If the FactIQ tools
+ever return an auth error, re-authorize to reconnect — the same connection
+covers both data fetching and publishing.
 
 ## Contents
 
 - `.mcp.json` — declares the bundled FactIQ MCP server (Streamable HTTP,
-  OAuth)
-- `SKILL.md` — the skill definition Claude loads (setup, workflow, limits)
-- `commands/ask.md` — the `/factiq:ask` slash command
+  OAuth). Read by both Claude Code and Codex plugin loaders.
+- `SKILL.md` — the skill definition both agents load (setup, workflow, limits)
+- `AGENTS.md` — Codex project-level instructions (points to SKILL.md)
+- `commands/ask.md` — the `/factiq:ask` slash command (Claude Code)
 - `scripts/build_viz.py` — local-only tool to assemble fetched data into a
   self-contained HTML viz and screenshot it headless for iteration. `assemble`
   is stdlib-only; `render` installs Playwright + Chromium into
@@ -69,18 +98,19 @@ failures too.
 - `assets/viz-shell.html` — starting-point shell for bespoke visualizations
 - `references/` — SQL idioms, ChartSpec/report formats, the bespoke-viz guide,
   and dataset schema overview
-- `.claude-plugin/` — plugin + marketplace manifests
+- `.claude-plugin/` — Claude Code plugin + marketplace manifests
+- `.codex-plugin/` — Codex plugin manifest
 
 ## Configuration
 
 The MCP server defaults to `https://api.factiq.com/mcp`. For local development
 against a local backend, set `FACTIQ_MCP_URL=http://localhost:8000/mcp` before
-starting Claude Code (it expands in `.mcp.json`).
+starting the coding agent (it expands in `.mcp.json`).
 
 ## Security
 
 No secrets belong in this repo, and the plugin holds none — all access goes
-through the MCP server's OAuth flow, so Claude Code holds the token and nothing
-is written here. The backend enforces a 1 request/second rate limit and a
-monthly tool-call quota per plan (publishing counts against the same quota as
+through the MCP server's OAuth flow, so the coding agent holds the token and
+nothing is written here. The backend enforces a 1 request/second rate limit and
+a monthly tool-call quota per plan (publishing counts against the same quota as
 the data tools).

--- a/SKILL.md
+++ b/SKILL.md
@@ -24,6 +24,17 @@ allowed-tools: >
   mcp__plugin_factiq_factiq__get_style_guides,
   mcp__plugin_factiq_factiq__share_chart,
   mcp__plugin_factiq_factiq__share_report,
+  mcp__factiq__get_data_catalog,
+  mcp__factiq__search_datasets,
+  mcp__factiq__describe_dataset,
+  mcp__factiq__search_series,
+  mcp__factiq__get_series,
+  mcp__factiq__run_sql,
+  mcp__factiq__get_market_data,
+  mcp__factiq__search_earnings,
+  mcp__factiq__get_style_guides,
+  mcp__factiq__share_chart,
+  mcp__factiq__share_report,
   Bash(python3:*), Bash(python:*), Read, Write
 ---
 
@@ -53,8 +64,8 @@ Three output modes:
 **Data in, output out:**
 
 - All discovery, fetching, **and publishing** go through the FactIQ **MCP
-  tools** (`mcp__plugin_factiq_factiq__*`). No codebase, database, or API key is
-  needed — Claude Code calls them directly over one authenticated connection.
+  tools** (`factiq MCP`). No codebase, database, or API key is
+  needed — the coding agent calls them directly over one authenticated connection.
 - The only local script is the bespoke-viz builder (it never touches the API):
 
   ```bash
@@ -67,22 +78,26 @@ Three output modes:
 ## Setup
 
 One connection covers everything: the FactIQ **MCP server** bundled with this
-plugin (`.mcp.json`), authorized over OAuth. On first use Claude Code runs
-FactIQ's browser-based **Connect** flow. If the `mcp__plugin_factiq_*` tools are
-missing or return an auth error, the connection isn't set up yet — tell the user
-to run **`/mcp`** in Claude Code, pick **factiq**, and complete the sign-in (the
-same FactIQ login: email, Google, or passkey). Nothing to copy or paste, and no
-separate key for publishing — the same connection authorizes `share_chart` /
-`share_report`.
+plugin (`.mcp.json`), authorized over OAuth. On first use the coding agent runs
+FactIQ's browser-based **Connect** flow. If the FactIQ tools are missing or
+return an auth error, the connection isn't set up yet — tell the user to
+authorize the MCP server:
+
+- **Claude Code**: run **`/mcp`**, pick **factiq**, and complete the sign-in.
+- **Codex**: run **`codex mcp login factiq`** and complete the sign-in.
+
+The same FactIQ login works everywhere (email, Google, or passkey). Nothing to
+copy or paste, and no separate key for publishing — the same connection
+authorizes `share_chart` / `share_report`.
 
 **Local development.** The MCP URL defaults to `https://api.factiq.com/mcp`;
 override it for a local backend by setting
-`FACTIQ_MCP_URL=http://localhost:8000/mcp` before Claude Code starts (it expands
-in `.mcp.json`).
+`FACTIQ_MCP_URL=http://localhost:8000/mcp` before the coding agent starts (it
+expands in `.mcp.json`).
 
 ## Tools
 
-All FactIQ tools are MCP tools (`mcp__plugin_factiq_factiq__*`).
+All FactIQ tools are MCP tools provided by the `factiq` MCP server.
 
 ### Data
 
@@ -249,9 +264,9 @@ to a JSON file before assembling.
 ## Errors and limits
 
 - **MCP tool unavailable / auth error** — the FactIQ MCP isn't connected. Tell
-  the user to run `/mcp`, pick **factiq**, and complete the Connect flow. The
-  same connection authorizes both the data tools and `share_chart` /
-  `share_report`, so this fixes publishing failures too.
+  the user to authorize it (Claude Code: `/mcp` → factiq; Codex:
+  `codex mcp login factiq`). The same connection authorizes both the data tools
+  and `share_chart` / `share_report`, so this fixes publishing failures too.
 - **429** — either the 1 request/second rate limit or the monthly tool-call
   quota (the error says when it resets). Note that publishing counts against the
   same monthly tool quota as the data tools. Don't burn calls re-fetching data

--- a/commands/ask.md
+++ b/commands/ask.md
@@ -14,6 +14,17 @@ allowed-tools: >
   mcp__plugin_factiq_factiq__get_style_guides,
   mcp__plugin_factiq_factiq__share_chart,
   mcp__plugin_factiq_factiq__share_report,
+  mcp__factiq__get_data_catalog,
+  mcp__factiq__search_datasets,
+  mcp__factiq__describe_dataset,
+  mcp__factiq__search_series,
+  mcp__factiq__get_series,
+  mcp__factiq__run_sql,
+  mcp__factiq__get_market_data,
+  mcp__factiq__search_earnings,
+  mcp__factiq__get_style_guides,
+  mcp__factiq__share_chart,
+  mcp__factiq__share_report,
   Bash(python3:*), Bash(python:*), Read, Write, AskUserQuestion
 ---
 
@@ -25,9 +36,9 @@ Read `${CLAUDE_PLUGIN_ROOT}/SKILL.md` first. If no question was provided
 above, ask the user what they want to know.
 
 Everything — discovery, fetching, and publishing — runs through the FactIQ MCP
-tools (`mcp__plugin_factiq_factiq__*`). If they aren't available or return an
-auth error, the MCP isn't connected — tell the user to run `/mcp`, pick
-**factiq**, and complete the Connect flow, then retry.
+tools. If they aren't available or return an auth error, the MCP isn't
+connected — tell the user to authorize it (Claude Code: `/mcp` → factiq;
+Codex: `codex mcp login factiq`), then retry.
 
 **Pick the output mode before doing any data work:**
 


### PR DESCRIPTION
## Summary
- Adds `.codex-plugin/plugin.json` and `AGENTS.md` so the plugin works with Codex out of the box
- Lists both MCP tool name prefixes (`mcp__plugin_factiq_factiq__*` for Claude Code plugin mode, `mcp__factiq__*` for Codex / direct MCP) in `allowed-tools` across `SKILL.md` and `commands/ask.md`
- Updates all prose (README, SKILL.md, ask.md) with dual setup and auth instructions — no more Claude Code-only language

## Test plan
- [ ] Install as a Claude Code plugin and verify the skill activates and tools resolve
- [ ] Install in Codex (`~/.codex/plugins/factiq`) and verify the skill activates and tools resolve
- [ ] Verify `share_chart` / `share_report` work from both agents
- [ ] Verify bespoke viz flow (`build_viz.py`) works from both agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LthyowjttfJoNAQ8cbnH3