### PR TITLE
Add build_viz.py save: persist raw tool results without retyping (#22)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, or build bespoke local HTML visualizations.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "Defog"
   }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, or build bespoke local HTML visualizations.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "Defog"
   },

--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ covers both data fetching and publishing.
 - `AGENTS.md` — Codex project-level instructions (points to SKILL.md)
 - `commands/ask.md` — the `/factiq:ask` slash command (Claude Code)
 - `scripts/build_viz.py` — local-only tool to assemble fetched data into a
-  self-contained HTML viz and screenshot it headless for iteration. `assemble`
-  is stdlib-only; `render` installs Playwright + Chromium into
-  `~/.factiq/viz-venv` on first use (no effect on your system Python)
+  self-contained HTML viz and screenshot it headless for iteration. `save`
+  copies a tool result's raw JSON out of the harness transcript to disk (no
+  retyping) and `assemble` are stdlib-only; `render` installs Playwright +
+  Chromium into `~/.factiq/viz-venv` on first use (no effect on your system
+  Python)
 - `assets/viz-shell.html` — starting-point shell for bespoke visualizations
 - `references/` — SQL idioms, ChartSpec/report formats, the bespoke-viz guide,
   and dataset schema overview

--- a/SKILL.md
+++ b/SKILL.md
@@ -134,8 +134,9 @@ field; nothing is published until it validates.
 
 ### Local viz — `build_viz.py`
 
-`build_viz.py assemble … / render …` builds + screenshots a bespoke local HTML
-viz (see **Bespoke local visualizations**). Local-only; never calls the API.
+`build_viz.py save … / assemble … / render …` saves raw tool results to disk
+(no retyping), builds, and screenshots a bespoke local HTML viz (see **Bespoke
+local visualizations**). Local-only; never calls the API.
 
 ## Orchestration workflow
 
@@ -171,10 +172,11 @@ viz (see **Bespoke local visualizations**). Local-only; never calls the API.
    `references/chart-spec.md`) with wide-format data rows and call
    `share_chart`; return the `share_url`. Report mode: build a report object
    (see `references/report-spec.md` and **Detailed reports** below) and call
-   `share_report`; return the `share_url`. Bespoke-viz mode: write the fetched
-   data to JSON files, author an HTML file, `build_viz.py assemble`,
-   `build_viz.py render` to screenshot and iterate, then give the user the local
-   file path (see **Bespoke local visualizations**).
+   `share_report`; return the `share_url`. Bespoke-viz mode: save each fetched
+   result to a JSON file with `build_viz.py save` (no retyping), author an HTML
+   file, `build_viz.py assemble`, `build_viz.py render` to screenshot and
+   iterate, then give the user the local file path (see **Bespoke local
+   visualizations**).
 
 ## Subagent orchestration
 
@@ -212,14 +214,22 @@ Steps:
 1. search_datasets / describe_dataset / search_series to find the right series.
 2. Fetch data with get_series or run_sql. Aggregate in SQL to stay under the
    50-row cap.
-3. Compute derived metrics (YoY, ratios, indices) yourself.
-4. Return your findings as a structured block:
+3. Save each fetched result to its own JSON file so a later charting step can
+   load the exact numbers instead of re-querying FactIQ or retyping them.
+   Right after each fetch, run (no retyping — it copies the payload from the
+   transcript), giving each file a thread-unique name and a --match on a
+   distinctive bit of your own SQL so a sibling agent's result can't be grabbed:
+   `python3 {skill_dir}/scripts/build_viz.py save --tool run_sql --match "<distinctive SQL fragment>" --out /tmp/factiq-raw/{thread_label}-<name>.json`
+4. Compute derived metrics (YoY, ratios, indices) yourself.
+5. Return your findings as a structured block:
 
 FINDINGS:
 - sub_question: (echo it back)
 - series_used: [{schema, series_id, title}, ...]
 - sql_queries: [the exact SQL you ran, formatted multi-line]
 - data: [{columns: [...], rows: [...]}, ...] — the actual fetched/computed values
+- raw_data_files: [/tmp/factiq-raw/{thread_label}-*.json, ...] — the files you
+  saved in step 3, so a downstream viz/report step loads exact data
 - key_insights: [1-3 sentences stating what the data shows, with numbers]
 - chart_suggestion: {chart_type, title, x_column, y_columns, units}
 ```
@@ -355,17 +365,28 @@ The tool is `scripts/build_viz.py` (local-only — it never calls the API):
 
 | Command | Purpose |
 |---|---|
+| `save --out F.json [--tool run_sql] [--match STR] [--index N] [--list]` | Copy a tool result's **raw JSON from the harness transcript** to `F.json` — the shell copies the bytes, you never retype the data. Feeds `assemble --data`. Stdlib only. |
 | `assemble --template T.html --data k1=f1.json k2=f2.json … --out O.html [--open]` | Inject on-disk JSON into your HTML at the `__FACTIQ_DATA__` marker; write one portable, self-contained file. Stdlib only. List **all** key=path pairs after the one `--data` flag. |
 | `render O.html [--out P.png] [--width N] [--height N] [--full-page] [--selector CSS] [--wait MS]` | Screenshot the file in headless Chromium and report JS/console errors + failed asset loads. Installs Playwright + Chromium into `~/.factiq/viz-venv` on first run (uses `uv` if available, else a stdlib venv). |
 
 The loop that makes this work — **fetch → save → author → assemble → render →
 look → fix**:
 
-1. Fetch the data with the MCP tools, then **write each result to a JSON file**
-   with the Write tool (the file holds the tool's own `{columns, results, …}`
-   payload — see `references/viz-guide.md` for the exact shape build_viz reads
-   back). Because the MCP caps results at 50 rows, this is context-cheap;
-   aggregate or window in SQL to get exactly the rows the viz needs.
+1. Fetch the data with the MCP tools, then **save each result to a JSON file
+   with `build_viz.py save` — do not retype it via Write**. The MCP tools return
+   their payload into your context, not to disk; `save` lifts that exact payload
+   back out of the harness transcript so the shell copies the bytes (never
+   re-emit a ~100-row result by hand — it double-pays the tokens and one
+   mistyped digit ships a wrong chart with no error). Run one `save` per fetch,
+   pinning the call with `--tool`/`--match`:
+   ```bash
+   python3 scripts/build_viz.py save --match "korea_customs" --out /tmp/korea.json
+   ```
+   The file holds the tool's own `{columns, results, …}` payload — see
+   `references/viz-guide.md` (**Saving data without retyping**) for `--list`,
+   `--index`, and the fallback when a transcript can't be found. Because the MCP
+   caps results at 50 rows, this is context-cheap; aggregate or window in SQL to
+   get exactly the rows the viz needs.
 2. Copy `assets/viz-shell.html`, add any CDN library you need, and author the
    viz. Keep the `__FACTIQ_DATA__` marker inside its
    `<script id="factiq-data" type="application/json">` tag — that exact element
@@ -395,8 +416,9 @@ is to **aggregate or compute it in SQL**, not to try to fetch the raw rows:
   make a few windowed calls and stitch them.
 
 Whatever you chart or report has to be the aggregated result you bring back —
-which is also all it needs. For `build_viz`, write that (already small) result
-to a JSON file before assembling.
+which is also all it needs. For `build_viz`, persist that (already small) result
+to a JSON file with `build_viz.py save` before assembling — it copies the
+payload from the transcript so you never retype the rows.
 
 ## Errors and limits
 

--- a/references/viz-guide.md
+++ b/references/viz-guide.md
@@ -12,12 +12,13 @@ layout, a multi-panel dashboard, a force/flow/chord diagram, an annotated
 narrative, a novel encoding, an interactive cross-filtered view, or just
 fine-grained control over a chart's look.
 
-## The two commands
+## The three commands
 
 `scripts/build_viz.py` is local-only (it never calls the FactIQ API):
 
 | Command | Purpose |
 |---|---|
+| `save --out F.json [--tool run_sql] [--match STR] [--index N] [--list]` | Copy a tool result's **raw JSON straight from the harness transcript** to `F.json` — the shell does the byte copy, you never retype the data. Feeds `assemble --data`. Stdlib only. See **Saving data without retyping** below. |
 | `assemble --template T --data k1=f1.json k2=f2.json … --out O.html [--open]` | Inject on-disk JSON into your HTML at the `__FACTIQ_DATA__` marker; write one portable file. Stdlib only. Pass **all** key=path pairs after the single `--data` flag (or repeat the flag — both work). |
 | `render H.html [--out P.png] [--width] [--height] [--full-page] [--selector CSS] [--wait MS]` | Screenshot the file in headless Chromium and report JS/console errors + failed requests. Installs Playwright + Chromium into `~/.factiq/viz-venv` on first run. |
 
@@ -27,13 +28,15 @@ stderr," not "minor warning."
 
 ## The workflow
 
-1. **Fetch the data with the MCP tools, then save each result to disk.** Call
-   `run_sql` / `get_series`, then write the tool's result to a JSON file with
-   the Write tool — `build_viz` reads its data from files, not from your
-   context. Results cap at 50 rows, so aggregate in SQL (`GROUP BY
-   date_trunc(...)`) or window a series to exactly the rows the viz needs. Save
-   the whole tool result (it carries `columns` + `results`), e.g. to
-   `/tmp/jobs.json`.
+1. **Fetch the data with the MCP tools, then save each result to disk with
+   `build_viz.py save` — do not retype it.** Call `run_sql` / `get_series` /
+   `get_market_data`, then run `save` to lift that tool's exact JSON payload out
+   of the harness transcript onto disk. `build_viz` reads its data from files,
+   not from your context, and `save` copies the bytes through the shell so you
+   never re-emit the numbers by hand (see **Saving data without retyping**).
+   Results cap at 50 rows, so aggregate in SQL (`GROUP BY date_trunc(...)`) or
+   window a series to exactly the rows the viz needs. `save` writes the whole
+   tool result (it carries `columns` + `results`), e.g. to `/tmp/jobs.json`.
 2. **Copy the shell and author the viz.** Start from `assets/viz-shell.html`
    (or write your own). Add any CDN `<script>` you need, then write the
    visualization. Keep the `__FACTIQ_DATA__` marker — that is where the data
@@ -69,6 +72,50 @@ stderr," not "minor warning."
 5. **Deliver.** Tell the user the file path; offer `assemble … --open` (or
    `open /tmp/out.html`) to open it in their browser. The file is portable and
    needs only internet for its CDN libraries.
+
+## Saving data without retyping
+
+`build_viz` reads its data from files, but the MCP tools return their payload
+into your **context**, not to disk. Never bridge that gap by hand-copying the
+rows into a `Write` call: re-emitting a payload you have already seen pays for
+every byte a second time as output tokens, and a single mistyped digit in a
+numeric literal (`11428031` → `11482031`) still parses as valid JSON and still
+renders — a wrong chart with no error to catch it.
+
+`build_viz.py save` closes the gap. The harness already writes every tool
+result to an on-disk transcript; `save` reads the exact payload back out of it
+and writes it to a file, so the **shell** copies the bytes and you never retype
+a number. It handles both Claude Code and Codex transcripts and auto-detects the
+live session.
+
+Right after a fetch, save its result:
+
+```bash
+# The most recent run_sql result → korea.json
+python3 scripts/build_viz.py save --tool run_sql --out /tmp/korea.json
+```
+
+- `--tool run_sql` (or `get_series`, `get_market_data`) keeps only that tool's
+  results, so an intervening `Bash`/`Read` call can't be grabbed by mistake.
+- `--match STR` pins the exact call by a substring of its **input** — a schema
+  name or a distinctive fragment of the SQL you just wrote — so it's
+  unambiguous even when you fetched several series in one turn:
+  ```bash
+  python3 scripts/build_viz.py save --match "korea_customs" --out /tmp/korea.json
+  python3 scripts/build_viz.py save --match "census" --out /tmp/census.json
+  ```
+- `--list` prints the matching results (tool, row count, input preview) with
+  their indices instead of saving — use it to pick, then `--index N` to save a
+  specific one. `--index` defaults to `-1` (the most recent match).
+- Output: `{out, tool, rows, input_preview}`. A non-JSON result (e.g. a plain
+  `Bash` result) can't be saved as viz data — narrow with `--tool`/`--match`.
+
+If `save` can't find the transcript (an unusual harness, or `--transcript` is
+wrong), it says so — only then fall back to writing the payload with `Write`.
+For a **multi-series** viz, run one `save` per fetch, then pass every file to
+`assemble --data`. This is also how a research subagent hands raw data to a
+later charting step (see SKILL.md **Subagent orchestration**): save each fetched
+result to a file and return the path, instead of re-querying FactIQ or retyping.
 
 ## The data contract
 

--- a/scripts/build_viz.py
+++ b/scripts/build_viz.py
@@ -24,6 +24,7 @@ value is the full factiq payload, so result rows live at DATA.<key>.results.
 from __future__ import annotations
 
 import argparse
+import glob
 import json
 import os
 import shutil
@@ -50,6 +51,267 @@ def _row_count(value: object) -> int | None:
     if isinstance(value, list):
         return len(value)
     return None
+
+
+# ---------------------------------------------------------------------------
+# save — lift a tool result out of the harness transcript onto disk
+#
+# The FactIQ MCP tools already return the full JSON payload into the model's
+# context. Re-emitting that same payload through a Write call to feed `assemble`
+# pays for every byte a second time (as output tokens) and risks a silent
+# transcription slip in a numeric literal. Instead, read the payload straight
+# from the on-disk transcript the harness already keeps and let the shell copy
+# the bytes — the model never retypes the data. Works for Claude Code and Codex.
+# ---------------------------------------------------------------------------
+
+CLAUDE_PROJECTS = os.path.expanduser("~/.claude/projects")
+CODEX_SESSIONS = os.path.expanduser("~/.codex/sessions")
+
+
+def _newest(paths: list[str]) -> str | None:
+    files = [p for p in paths if os.path.isfile(p)]
+    return max(files, key=os.path.getmtime) if files else None
+
+
+def _claude_transcript_for_cwd() -> str | None:
+    # Claude Code stores each session at ~/.claude/projects/<slug>/<uuid>.jsonl,
+    # where <slug> is the working directory with every "/" turned into "-".
+    slug = os.getcwd().replace("/", "-")
+    here = _newest(glob.glob(os.path.join(CLAUDE_PROJECTS, slug, "*.jsonl")))
+    if here:
+        return here
+    # Subagents/commands may run from a different cwd; fall back to the globally
+    # newest Claude transcript (the live session is the one being written).
+    return _newest(glob.glob(os.path.join(CLAUDE_PROJECTS, "*", "*.jsonl")))
+
+
+def _codex_transcript() -> str | None:
+    return _newest(
+        glob.glob(os.path.join(CODEX_SESSIONS, "**", "*.jsonl"), recursive=True)
+    )
+
+
+def _find_transcript() -> str | None:
+    """Locate the live harness transcript — whichever of Claude Code / Codex was
+    written most recently, since that is the session running right now."""
+    cands = [p for p in (_claude_transcript_for_cwd(), _codex_transcript()) if p]
+    return max(cands, key=os.path.getmtime) if cands else None
+
+
+def _sniff_kind(path: str) -> str:
+    if os.sep + ".codex" + os.sep in path:
+        return "codex"
+    if os.sep + ".claude" + os.sep in path:
+        return "claude"
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                obj = json.loads(line)
+                if isinstance(obj.get("payload"), dict):
+                    return "codex"
+                if isinstance(obj.get("message"), dict):
+                    return "claude"
+    except (OSError, json.JSONDecodeError):
+        pass
+    return "claude"
+
+
+def _result_text(content: object) -> str:
+    """Flatten a tool_result / MCP content value to its text payload."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            b.get("text", "")
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        ]
+        return "".join(parts)
+    return ""
+
+
+def _dumps_input(inp: object) -> str:
+    if isinstance(inp, str):
+        return inp
+    try:
+        return json.dumps(inp, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(inp)
+
+
+def _make_record(tool: str, input_str: str, text: str) -> dict:
+    parsed: object | None = None
+    if text:
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            parsed = None
+    # Some clients store an MCP result as its raw envelope
+    # {"content": [{"type": "text", "text": "<json>"}]}; unwrap it to the actual
+    # payload so the saved file is the tool's data, not the transport wrapper.
+    if (
+        isinstance(parsed, dict)
+        and "content" in parsed
+        and "results" not in parsed
+        and "columns" not in parsed
+    ):
+        inner = _result_text(parsed.get("content"))
+        if inner:
+            try:
+                parsed = json.loads(inner)
+                text = inner
+            except (json.JSONDecodeError, TypeError):
+                pass
+    rows = _row_count(parsed) if parsed is not None else None
+    return {"tool": tool, "input": input_str, "json": parsed, "rows": rows}
+
+
+def _parse_claude(path: str) -> list[dict]:
+    names: dict[str, tuple[str, str]] = {}
+    results: list[tuple[str, str]] = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            msg = obj.get("message")
+            content = msg.get("content") if isinstance(msg, dict) else None
+            if not isinstance(content, list):
+                continue
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get("type") == "tool_use":
+                    names[b.get("id")] = (
+                        b.get("name", ""),
+                        _dumps_input(b.get("input")),
+                    )
+                elif b.get("type") == "tool_result":
+                    results.append(
+                        (b.get("tool_use_id"), _result_text(b.get("content")))
+                    )
+    out = []
+    for tuid, text in results:
+        name, inp = names.get(tuid, ("", ""))
+        out.append(_make_record(name, inp, text))
+    return out
+
+
+def _parse_codex(path: str) -> list[dict]:
+    names: dict[str, tuple[str, str]] = {}
+    results: list[tuple[str, str]] = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            p = obj.get("payload") if isinstance(obj.get("payload"), dict) else obj
+            pt = p.get("type")
+            if pt == "function_call":
+                names[p.get("call_id")] = (p.get("name", ""), p.get("arguments", "") or "")
+            elif pt == "function_call_output":
+                out = p.get("output")
+                text = out if isinstance(out, str) else _result_text(out)
+                results.append((p.get("call_id"), text))
+    recs = []
+    for cid, text in results:
+        name, inp = names.get(cid, ("", ""))
+        recs.append(_make_record(name, inp, text))
+    return recs
+
+
+def _tool_matches(name: str, wanted: str) -> bool:
+    if not name:
+        return False
+    if name == wanted or name.split("__")[-1] == wanted:
+        return True
+    return wanted in name
+
+
+def cmd_save(args: argparse.Namespace) -> None:
+    path = args.transcript or _find_transcript()
+    if not path:
+        fail(
+            "Could not locate a harness transcript. Pass --transcript PATH, or "
+            "fall back to writing the payload with the Write tool."
+        )
+    if not os.path.isfile(path):
+        fail(f"No such transcript: {path}")
+
+    recs = _parse_codex(path) if _sniff_kind(path) == "codex" else _parse_claude(path)
+
+    sel = recs
+    if args.tool:
+        sel = [r for r in sel if _tool_matches(r["tool"], args.tool)]
+    if args.match:
+        m = args.match.lower()
+        sel = [
+            r
+            for r in sel
+            if m in (r["input"] or "").lower() or m in (r["tool"] or "").lower()
+        ]
+
+    if args.list or not args.out:
+        listing = [
+            {
+                "index": i,
+                "neg_index": i - len(sel),
+                "tool": r["tool"] or None,
+                "rows": r["rows"],
+                "json": r["json"] is not None,
+                "input_preview": (r["input"] or "")[:120],
+            }
+            for i, r in enumerate(sel)
+        ]
+        print(json.dumps({"transcript": path, "results": listing}, indent=2))
+        if not args.out and not args.list:
+            fail("Nothing saved: pass --out FILE to save one of the results above.")
+        return
+
+    if not sel:
+        fail(
+            "No tool result matched. Re-run with --list (optionally --tool "
+            "run_sql) to see what the transcript holds."
+        )
+    try:
+        rec = sel[args.index]
+    except IndexError:
+        fail(f"--index {args.index} is out of range; {len(sel)} result(s) matched.")
+    if rec["json"] is None:
+        fail(
+            "The matched result is not JSON, so it can't be saved as viz data. "
+            "Use --list to pick another (narrow with --tool/--match)."
+        )
+
+    out = os.path.abspath(args.out)
+    parent = os.path.dirname(out)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    try:
+        with open(out, "w") as f:
+            json.dump(rec["json"], f)
+    except OSError as exc:
+        fail(f"Cannot write {out}: {exc}")
+
+    stub = {
+        "out": out,
+        "tool": rec["tool"] or None,
+        "input_preview": (rec["input"] or "")[:120],
+    }
+    if rec["rows"] is not None:
+        stub["rows"] = rec["rows"]
+    print(json.dumps(stub, indent=2))
 
 
 def _escape_for_html(text: str) -> str:
@@ -320,6 +582,47 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--out", required=True, help="Output HTML path")
     p.add_argument("--open", action="store_true", help="Open the result in the browser")
     p.set_defaults(func=cmd_assemble)
+
+    p = sub.add_parser(
+        "save",
+        help="Copy a tool result's raw JSON from the harness transcript to a "
+        "file — no retyping (feeds assemble --data)",
+    )
+    p.add_argument(
+        "--out",
+        help="Where to write the extracted JSON. Omit (or pass --list) to just "
+        "list the available results without saving.",
+    )
+    p.add_argument(
+        "--tool",
+        help="Only match results from this tool, e.g. run_sql / get_series / "
+        "get_market_data (matches the MCP tool-name suffix).",
+    )
+    p.add_argument(
+        "--match",
+        help="Only match results whose tool input contains this substring "
+        "(case-insensitive) — e.g. a schema name or a distinctive bit of your "
+        "SQL. Lets you pin the exact call without reading its output back.",
+    )
+    p.add_argument(
+        "--index",
+        type=int,
+        default=-1,
+        help="Which of the matching results to save (default -1, the most "
+        "recent). Use --list to see indices.",
+    )
+    p.add_argument(
+        "--list",
+        action="store_true",
+        help="List the matching results (tool, row count, input preview) "
+        "instead of saving.",
+    )
+    p.add_argument(
+        "--transcript",
+        help="Transcript file to read (default: auto-detect the live Claude "
+        "Code / Codex session).",
+    )
+    p.set_defaults(func=cmd_save)
 
     p = sub.add_parser(
         "render",


### PR DESCRIPTION
Fixes #22.

## Problem

The bespoke-viz workflow told the agent to feed `build_viz assemble --data` by hand-copying each MCP tool result into a `Write` call. Since the payload was already in context from the tool call, this:

1. **Paid the tokens twice** — re-emitting the data as *output* (the expensive direction).
2. **Silently corrupted data** — a mistyped digit (`11428031` → `11482031`) still parses as valid JSON and still renders a chart, just a wrong one, with no error to catch it.
3. **Degraded fidelity** — retyping a ~100-row `get_market_data` payload five times pressures the agent to downsample, i.e. the cost structure rewards doing a *worse* job than the data supports.
4. **Compounded under subagent orchestration** — research subagents had no way to hand back raw arrays, so the charting phase re-queried FactIQ for data a sibling had already fetched.

The MCP server is a remote HTTP service, so it can't write to the client's disk — but the harness already writes every tool result to an on-disk transcript. The fix reads the payload back from there.

## Fix

A new `build_viz.py save` subcommand lifts a tool result's exact JSON out of the harness transcript onto disk — the shell copies the bytes, the model never retypes the data.

```bash
# Right after a run_sql fetch:
python3 scripts/build_viz.py save --match "korea_customs" --out /tmp/korea.json
```

- **Auto-detects** the live session — Claude Code (`~/.claude/projects/<slug>/*.jsonl`) or Codex (`~/.codex/sessions/**/rollout-*.jsonl`), whichever was written most recently. `--transcript` overrides.
- Resolves each result's **tool name + input** by joining `tool_use`/`function_call` to its result, so you can pin the exact call with `--tool run_sql` / `--match "<sql fragment>"` — no reading the output back.
- `--list` (or omitting `--out`) prints the matching results — tool, row count, input preview, indices — so you can pick with `--index`.
- Unwraps the `{"content":[{"type":"text",...}]}` MCP envelope when a client stores it wrapped. Non-JSON results (e.g. a `Bash` result) are rejected with a clear message; if the transcript can't be found it falls back to advising `Write`.
- Stdlib only.

## Docs

- `references/viz-guide.md` — new **Saving data without retyping** section; `save` added to the commands table; workflow step 1 rewritten.
- `SKILL.md` — the bespoke loop and Context-budget guidance now use `save` instead of `Write`; the subagent-orchestration research template saves raw arrays to per-thread files and returns them in a new `raw_data_files` findings field, so downstream steps load exact data instead of re-querying.
- `README.md` — script description updated.

## Version

Both plugin manifests bumped `0.9.0` → `0.10.0`.

## Testing

Verified against synthetic **and** the live session transcript for both harness formats: `--list`, `--tool`/`--match` filtering, `--index`, MCP-envelope unwrap, the no-match/non-JSON error paths, and end-to-end `save → assemble` (large integer `11428031` preserved byte-for-byte into the assembled HTML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015k5cQynJECxeZiACw1ePWS