### PR TITLE
[codex] Fix FactIQ MCP URL config

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, or build bespoke local HTML visualizations.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "Defog"
   }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, or build bespoke local HTML visualizations.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "Defog"
   },

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "factiq": {
       "type": "http",
-      "url": "${FACTIQ_MCP_URL:-https://api.factiq.com/mcp}"
+      "url": "https://api.factiq.com/mcp"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -111,9 +111,10 @@ covers both data fetching and publishing.
 
 ## Configuration
 
-The MCP server defaults to `https://api.factiq.com/mcp`. For local development
-against a local backend, set `FACTIQ_MCP_URL=http://localhost:8000/mcp` before
-starting the coding agent (it expands in `.mcp.json`).
+The bundled MCP server points at `https://api.factiq.com/mcp`. For local
+development against a local backend, edit `.mcp.json` in your development
+checkout or configure a standalone `factiq` MCP server in Codex or Claude Code
+that points at the local URL.
 
 ## Security
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -90,10 +90,10 @@ The same FactIQ login works everywhere (email, Google, or passkey). Nothing to
 copy or paste, and no separate key for publishing — the same connection
 authorizes `share_chart` / `share_report`.
 
-**Local development.** The MCP URL defaults to `https://api.factiq.com/mcp`;
-override it for a local backend by setting
-`FACTIQ_MCP_URL=http://localhost:8000/mcp` before the coding agent starts (it
-expands in `.mcp.json`).
+**Local development.** The bundled MCP URL is
+`https://api.factiq.com/mcp`. For a local backend, edit `.mcp.json` in your
+development checkout or configure a standalone `factiq` MCP server in Codex or
+Claude Code that points at the local URL.
 
 ## Tools
 

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -90,10 +90,10 @@ The same FactIQ login works everywhere (email, Google, or passkey). Nothing to
 copy or paste, and no separate key for publishing — the same connection
 authorizes `share_chart` / `share_report`.
 
-**Local development.** The MCP URL defaults to `https://api.factiq.com/mcp`;
-override it for a local backend by setting
-`FACTIQ_MCP_URL=http://localhost:8000/mcp` before the coding agent starts (it
-expands in `.mcp.json`).
+**Local development.** The bundled MCP URL is
+`https://api.factiq.com/mcp`. For a local backend, edit `.mcp.json` in your
+development checkout or configure a standalone `factiq` MCP server in Codex or
+Claude Code that points at the local URL.
 
 ## Tools
 


### PR DESCRIPTION
## Summary
- replace the bundled FactIQ MCP URL with a literal `https://api.factiq.com/mcp` value
- remove docs that claimed `${FACTIQ_MCP_URL:-...}` expansion works in `.mcp.json`
- bump plugin manifests to `0.10.1` so Codex installs a fresh package

## Why
`codex mcp login factiq` was parsing `${FACTIQ_MCP_URL:-https://api.factiq.com/mcp}` literally and failing with `relative URL without a base`. Codex expects the MCP `url` field to be an absolute URL, not shell-style parameter expansion.

## Validation
- `python3 /Users/rishabh/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py /Users/rishabh/defog/factiq/factiq-plugin`
- `python3 /Users/rishabh/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/factiq`
- `cmp -s SKILL.md skills/factiq/SKILL.md`
- `jq . .mcp.json .codex-plugin/plugin.json .claude-plugin/plugin.json`
- isolated `CODEX_HOME` smoke test: `codex plugin marketplace add /Users/rishabh/defog/factiq/factiq-plugin`, `codex plugin add factiq@factiq --json`, and `codex mcp get factiq` showing `url: https://api.factiq.com/mcp`