### PR TITLE
[codex] Document FactIQ marketplace upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Complete the browser sign-in (the same FactIQ login: email, Google, or
 passkey). Start a new Codex thread after installation; the skill auto-invokes
 for economic/financial data questions.
 
+To update an existing Codex install after this marketplace changes, refresh the
+configured marketplace name (`factiq`), then reinstall the plugin:
+
+```bash
+codex plugin marketplace upgrade factiq
+codex plugin add factiq@factiq
+```
+
 <details>
 <summary>Alternative: install as a standalone MCP server (no plugin)</summary>
 


### PR DESCRIPTION
## Summary
- document the correct Codex marketplace refresh command for existing FactIQ installs
- clarify that `factiq` is the configured marketplace name to pass to `codex plugin marketplace upgrade`

## Why
`codex plugin marketplace upgrade defog-ai/factiq-plugin` treats the GitHub shorthand as a marketplace name and fails. After `codex plugin marketplace add defog-ai/factiq-plugin`, Codex registers the marketplace under the name from `.agents/plugins/marketplace.json`: `factiq`.

## Validation
- `python3 /Users/rishabh/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py /Users/rishabh/defog/factiq/factiq-plugin`
- `codex plugin marketplace upgrade factiq`