### PR TITLE
[codex] Port FactIQ report guidance PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ covers both data fetching and publishing.
   Chromium into `~/.factiq/viz-venv` on first use (no effect on your system
   Python)
 - `assets/viz-shell.html` — starting-point shell for bespoke visualizations
-- `references/` — SQL idioms, ChartSpec/report formats, the bespoke-viz guide,
-  and dataset schema overview
+- `references/` — SQL idioms, ChartSpec/report formats, monetary policy,
+  bilateral trade, bilateral economic-policy, and fiscal-policy revenue report
+  patterns, the bespoke-viz guide, and dataset schema overview
 - `.claude-plugin/` — Claude Code plugin + marketplace manifests
 - `.codex-plugin/` — Codex plugin manifest
 

--- a/references/bilateral-economic-policy.md
+++ b/references/bilateral-economic-policy.md
@@ -1,0 +1,153 @@
+# Bilateral Economic-Policy Report Pattern
+
+Use this guide for country-pair questions about joint economic policy,
+bilateral policy comparisons, or broad policy areas such as trade policy,
+investment policy, industrial strategy, supply-chain cooperation, energy
+security, digital policy, or financial-market cooperation.
+
+This guide is for the full economic concept. Do not reduce a broad policy
+question to the easiest database slice. If the user asks specifically for
+merchandise trade, customs flows, HS product drivers, exports, imports, or
+trade balances, use `bilateral-trade.md`. If the user asks for trade policy or
+economic policy more broadly, use this guide and pull in `bilateral-trade.md`
+only for the merchandise-goods portion.
+
+## Trigger phrases
+
+Default to this pattern for prompts like:
+
+- "Compare A and B trade policy."
+- "What is the joint economic policy between A and B?"
+- "How are A and B coordinating on investment, trade, or supply chains?"
+- "Discuss A and B's economic relationship and policy direction."
+- "How are global policy changes affecting A and B's bilateral relationship?"
+
+If the prompt is ambiguous, decide from wording:
+
+- **Merchandise-trade wording**: "goods trade", "exports/imports",
+  "trade balance", "HS", "customs", or "product drivers" means
+  `bilateral-trade.md`.
+- **Policy wording**: "trade policy", "economic policy", "joint policy",
+  "negotiations", "barriers", "investment", "services", "FDI", "supply
+  chains", "industrial policy", or "third-country impact" means this guide.
+
+## Minimum answer
+
+A good bilateral economic-policy report should include:
+
+- The policy concept being compared, with its important dimensions named up
+  front.
+- Database-backed indicators for every dimension FactIQ can support in the
+  current session.
+- Current official-source context for bilateral talks, agreements, stated
+  policy goals, market-access issues, and sector priorities.
+- Third-country policy context when a large economy plausibly affects either
+  country's incentives or negotiating position.
+- Explicit gaps for dimensions that matter but cannot be quantified from
+  available FactIQ data or current sources.
+- Clear separation between measured data, official policy statements, and the
+  analyst's inference.
+
+## Trade-policy checklist
+
+For broad bilateral trade-policy reports, do not stop at goods trade. Cover the
+following dimensions unless the user narrows the question:
+
+1. **Goods trade.** Merchandise exports, imports, balance, product drivers, and
+   reporter/source caveats. Use `bilateral-trade.md` for the HS/customs data
+   workflow.
+2. **Services trade.** Search FactIQ and current official sources for bilateral
+   services data or services-policy priorities. If bilateral services data is
+   unavailable, state the gap and use country-level context only when it is
+   relevant and clearly labeled.
+3. **FDI and investment.** Look for bilateral FDI stocks/flows, investment
+   approvals, sectoral investment announcements, investment-promotion
+   programs, and investment-screening rules.
+4. **Tariff barriers.** Cover applied tariffs, FTA/CEPA tariff schedules,
+   safeguard measures, anti-dumping or countervailing duties, and rules of
+   origin where relevant.
+5. **Non-tariff barriers.** Cover standards, certification, sanitary or
+   phytosanitary rules, customs procedures, localization rules, data rules,
+   licensing, procurement access, and conformity assessment.
+6. **Bilateral talks and joint agenda.** Check official FTA/CEPA review pages,
+   joint statements, trade-ministry releases, summit communiques, MoUs, sector
+   working groups, and regulatory-cooperation announcements.
+7. **Sector strategy.** Identify industries the countries are encouraging or
+   protecting, such as electronics, semiconductors, autos, steel, chemicals,
+   batteries, critical minerals, energy, agriculture, digital services, health,
+   finance, or defense supply chains.
+8. **Third-country pressure.** Check whether US, China, EU, Japan, Gulf, ASEAN,
+   or other major-economy policies are changing incentives through tariffs,
+   subsidies, export controls, sanctions, de-risking, friend-shoring,
+   investment screening, carbon border measures, or supply-chain programs.
+
+## Data workflow
+
+1. Call `get_data_catalog` first and skip schemas listed under
+   `schemas_without_data`.
+2. Search broadly before fetching. Use dataset searches for the country names
+   plus the concept terms: `trade`, `services`, `FDI`, `investment`, `balance
+   of payments`, `tariff`, `industry`, `energy`, `digital`, or the sector the
+   user named.
+3. For goods trade, follow `bilateral-trade.md` and reuse its lineage rules.
+4. For services and FDI, prefer bilateral series when available. If only
+   country-level aggregates are available, use them as context rather than as
+   proof of the bilateral relationship.
+5. For policy details, use current official sources where possible: trade and
+   industry ministries, investment-promotion agencies, central banks,
+   statistical agencies, customs authorities, WTO/UNCTAD/OECD/World Bank/IMF
+   pages, official FTA/CEPA pages, and government press releases.
+6. For third-country context, use current official sources from the relevant
+   third country or multilateral institution first. Use news or private
+   analysis only when official sources do not cover the issue, and label the
+   source type clearly.
+7. Do local computation for ratios, growth rates, shares, and comparisons from
+   fetched data. Do not infer causality from timing alone.
+
+## Default report shape
+
+Use 3-5 sections depending on data availability:
+
+1. **Policy map.** Define the concept, identify the active policy dimensions,
+   and state which dimensions have data versus source-only context.
+2. **Measured bilateral relationship.** Show goods, services, FDI, or sector
+   indicators that can be fetched. For goods, include the main merchandise
+   trend and balance rather than every product-driver table unless product
+   composition is central to the policy story.
+3. **Negotiation agenda and barriers.** Summarize active bilateral talks,
+   agreements under review, market-access goals, tariff and non-tariff
+   barriers, investment initiatives, and regulatory-cooperation items.
+4. **Third-country pressure.** Explain major external policies that could be
+   changing either country's posture, and identify whether the pressure is
+   likely to amplify, dampen, or redirect bilateral cooperation.
+5. **Caveats and open gaps.** State data lags, missing bilateral services or
+   FDI data, source asymmetries, and where policy inference is not proved by
+   the measured data.
+
+## Common concept checklists
+
+Use these as starting points. Add or remove dimensions to fit the user's
+specific question.
+
+| Concept | Dimensions to check |
+|---|---|
+| Trade policy | Goods, services, FDI/investment, tariffs, non-tariff barriers, rules of origin, standards, customs, digital trade, supply chains, bilateral talks, third-country pressure |
+| Investment policy | FDI stocks/flows, sector restrictions, screening rules, incentives, tax treaties, investment-promotion agreements, dispute mechanisms, strategic sectors, third-country capital controls or sanctions |
+| Industrial policy | Target sectors, subsidies/incentives, local-content rules, procurement, technology transfer, supply-chain resilience, export controls, critical minerals, energy inputs, third-country subsidy or tariff programs |
+| Energy policy | Fuel trade, electricity or grid cooperation, LNG/oil/coal exposure, renewables, critical minerals, climate rules, energy security agreements, carbon border measures, third-country sanctions or supply disruptions |
+| Digital/services policy | Services trade, data localization, cross-border data rules, payments, fintech, telecom, AI/cloud policy, professional services access, visa/labor mobility, cybersecurity rules, major-platform regulation |
+
+## Reporting rules
+
+- Do not imply that merchandise trade explains all trade policy unless the
+  prompt asks only for goods.
+- Do not silently omit services, FDI, or investment from a trade-policy report.
+  If the data is unavailable, say so and explain how that limits the answer.
+- Keep official policy statements separate from measured economic outcomes.
+  Use cautious language such as "could support", "could weigh on", or "is
+  consistent with" unless the data and sources directly prove causality.
+- Every numeric claim must come from fetched data in the current session.
+- Every chart/table should carry database sources and lineage. Policy sections
+  should cite current source URLs in report sources or methodology notes.
+- When third-country policy context is included, explain why it matters for the
+  two-country relationship rather than listing unrelated global developments.

--- a/references/bilateral-trade.md
+++ b/references/bilateral-trade.md
@@ -1,0 +1,498 @@
+# Bilateral Trade Report Pattern
+
+Use this guide for broad country-pair merchandise trade questions, especially
+phrases like "latest trend in trade between A and B", "what is driving trade",
+"trade balance between A and B", or "compare exports and imports between A and
+B". Unless the user explicitly asks for only a quick chart, treat these as
+report-style requests and publish a compact `share_report`.
+
+Do not use this file alone for broad "trade policy" or "economic policy"
+questions. Those questions need the wider concept checklist in
+`bilateral-economic-policy.md`, including services trade, FDI/investment,
+tariff and non-tariff barriers, bilateral talks, sector strategy, and
+third-country policy pressure. Use this file only for the merchandise-goods
+portion of those reports.
+
+Read `report-spec.md` before authoring the report object. This file covers the
+extra data work and caveats that bilateral trade reports need.
+
+## Minimum answer
+
+A good bilateral trade report should include:
+
+- Latest available month for each source, with exact month and coverage.
+- Latest month versus the same month one year earlier.
+- Year-to-date (YTD) totals through the latest common month versus prior-year
+  YTD.
+- Previous full-year context, usually the prior 2-3 years.
+- Exports, imports, total trade, and trade balance. State the reporter view:
+  reporter exports minus reporter imports.
+- Product or industry driver tables for both directions of trade, at one HS
+  level, with HS code, product label, current value, prior-year value, change,
+  and contribution to the net change.
+- A policy-context section based on current official sources when policy could
+  affect the trend.
+- Source caveats, especially when using mirror statistics from both reporters.
+
+The default report shape is 3-4 sections:
+
+1. **Headline trend and source coverage.** Latest common month, YTD read, and
+   whether both reporters agree on the direction.
+2. **Trend versus prior years.** One line chart of monthly exports/imports plus
+   a table of annual and YTD totals, growth rates, and balance.
+3. **Product drivers.** Two compact tables: A exports to B / B imports from A,
+   and B exports to A / A imports from B. Prefer YTD drivers over latest-month
+   drivers unless the latest-month move is the point of the question.
+4. **Policy context and caveats.** Current trade agreement status, tariff and
+   non-tariff issues, industrial/supply-chain policies, and source asymmetry.
+
+## Data workflow
+
+1. Call `get_data_catalog` first and skip schemas listed under
+   `schemas_without_data`.
+2. Use `search_datasets` for both country names plus `trade`, `customs`, and
+   `HS`; then `describe_dataset` for each candidate trade dataset.
+3. Query each reporter schema separately. `run_sql` operates inside one schema,
+   so do not try to join India and Korea, China and US, etc. in one SQL call.
+   Fetch comparable aggregates from each reporter, then normalize units and
+   compare locally.
+4. Use the `dimensions` table to filter partner, flow, commodity, and HS level.
+   Do not parse series IDs unless dimension filters are unavailable.
+5. Use exactly one HS level per table. Use HS-6 for cross-country comparison.
+   Use national 8/10-digit detail only for within-reporter detail, and never
+   sum national-detail rows together with HS-6 rows.
+6. Filter value series separately from quantity/weight series. Korea KCS, China
+   GACC, Japan Customs, and US Census 10-digit series can include physical
+   quantities. A value report should exclude `kg`, quantity, or `_qty` series.
+7. Normalize units before comparing reporters. For example, India DGCI&S is
+   `US$ Million`; Korea KCS value series are `US$ Thousand`, so divide Korea
+   values by 1,000 before comparing them to India values in US$ millions.
+8. State reporter/source differences. Mirror statistics often differ because
+   of FOB/CIF valuation, timing, exchange-rate conversion, re-exports,
+   confidentiality suppressions, revisions, and reporter-specific definitions.
+   Do not average reporters by default.
+
+Useful India-South Korea substitutions:
+
+| Reporter view | Schema | Partner filter | HS level | Value units |
+|---|---|---|---|---|
+| India-reported trade with South Korea | `india_trade` | `partner.dimension_code = '217'` (`KOREA RP`) | `hs_level.dimension_code = '6'` | `US$ Million` |
+| Korea-reported trade with India | `korea_trade` | `partner.dimension_code = 'IN'` (`India`) | `hs_level.dimension_code = '6'` | `US$ Thousand`; divide by 1,000 |
+
+## SQL templates
+
+The templates below assume a trade schema with dimensions named `partner`,
+`flow`, `commodity`, `hs_level`, and `reporter` (the structure used by
+`india_trade`, `korea_trade`, `china_customs`, and similar customs schemas).
+Replace:
+
+- `<dataset>` with the dataset code, often the same as the schema.
+- `<partner_code>` with the code discovered from `dimensions`.
+- `<hs_level_code>` with the selected level, usually `6`.
+- `<value_units>` with the value unit to keep, such as `US$ Million` or
+  `US$ Thousand`.
+- `<unit_divisor_to_usd_mn>` with `1` for US$ millions, `1000` for US$
+  thousands, and `1000000` for raw US dollars.
+
+### Discover partner, flow, HS, and units
+
+Run this before aggregating so the filters are explicit and auditable:
+
+```sql
+SELECT d.dimension_type, d.dimension_code, d.dimension_name, COUNT(*) AS n
+FROM dimensions d
+JOIN series s USING (series_id)
+WHERE s.dataset_code ILIKE '<dataset>'
+  AND d.dimension_type IN ('partner', 'flow', 'hs_level', 'reporter')
+GROUP BY d.dimension_type, d.dimension_code, d.dimension_name
+ORDER BY d.dimension_type, n DESC
+LIMIT 50;
+```
+
+Then verify value units:
+
+```sql
+SELECT measurement_units, COUNT(*) AS n
+FROM series
+WHERE dataset_code ILIKE '<dataset>'
+GROUP BY measurement_units
+ORDER BY n DESC;
+```
+
+### Monthly totals by flow
+
+This is the base query for line charts, latest-month comparisons, balances, and
+annual/YTD tables. The final SELECT returns the latest 24 months so the result
+stays under the row cap for two flows; use the aggregate templates below for
+longer annual history.
+
+```sql
+WITH bilateral_series AS (
+  SELECT s.series_id,
+         f.dimension_code AS flow_code,
+         f.dimension_name AS flow
+  FROM series s
+  JOIN dimensions p ON p.series_id = s.series_id
+      AND p.dimension_type = 'partner'
+      AND p.dimension_code = '<partner_code>'
+  JOIN dimensions f ON f.series_id = s.series_id
+      AND f.dimension_type = 'flow'
+  JOIN dimensions h ON h.series_id = s.series_id
+      AND h.dimension_type = 'hs_level'
+      AND h.dimension_code = '<hs_level_code>'
+  WHERE s.dataset_code ILIKE '<dataset>'
+    AND s.measurement_units = '<value_units>'
+),
+monthly AS (
+  SELECT date_trunc('month', dp.time)::date AS month,
+         bs.flow_code,
+         bs.flow,
+         SUM(dp.value) / <unit_divisor_to_usd_mn> AS value_usd_mn
+  FROM data_points dp
+  JOIN bilateral_series bs USING (series_id)
+  GROUP BY 1, 2, 3
+)
+SELECT month, flow_code, flow, value_usd_mn
+FROM monthly
+WHERE month >= (SELECT MAX(month) FROM monthly) - INTERVAL '24 months'
+ORDER BY month, flow_code;
+```
+
+Use this output to compute `total_trade = exports + imports` and
+`balance = exports - imports` from the reporter's perspective. If exports and
+imports have different latest months, use the latest common month for total
+trade and balance, then state any source lag.
+
+### Latest common month versus one year earlier
+
+```sql
+WITH bilateral_series AS (
+  SELECT s.series_id,
+         f.dimension_code AS flow_code,
+         f.dimension_name AS flow
+  FROM series s
+  JOIN dimensions p ON p.series_id = s.series_id
+      AND p.dimension_type = 'partner'
+      AND p.dimension_code = '<partner_code>'
+  JOIN dimensions f ON f.series_id = s.series_id
+      AND f.dimension_type = 'flow'
+  JOIN dimensions h ON h.series_id = s.series_id
+      AND h.dimension_type = 'hs_level'
+      AND h.dimension_code = '<hs_level_code>'
+  WHERE s.dataset_code ILIKE '<dataset>'
+    AND s.measurement_units = '<value_units>'
+),
+monthly AS (
+  SELECT date_trunc('month', dp.time)::date AS month,
+         bs.flow_code,
+         bs.flow,
+         SUM(dp.value) / <unit_divisor_to_usd_mn> AS value_usd_mn
+  FROM data_points dp
+  JOIN bilateral_series bs USING (series_id)
+  GROUP BY 1, 2, 3
+),
+common_latest AS (
+  SELECT month AS latest_month
+  FROM monthly
+  GROUP BY month
+  HAVING COUNT(DISTINCT flow_code) = 2
+  ORDER BY month DESC
+  LIMIT 1
+),
+paired AS (
+  SELECT m.flow_code,
+         m.flow,
+         cl.latest_month,
+         SUM(m.value_usd_mn) FILTER (
+           WHERE m.month = cl.latest_month
+         ) AS latest_value_usd_mn,
+         SUM(m.value_usd_mn) FILTER (
+           WHERE m.month = cl.latest_month - INTERVAL '1 year'
+         ) AS prior_year_value_usd_mn
+  FROM monthly m
+  CROSS JOIN common_latest cl
+  WHERE m.month IN (cl.latest_month, cl.latest_month - INTERVAL '1 year')
+  GROUP BY m.flow_code, m.flow, cl.latest_month
+)
+SELECT flow_code,
+       flow,
+       latest_month,
+       latest_value_usd_mn,
+       prior_year_value_usd_mn,
+       latest_value_usd_mn - prior_year_value_usd_mn AS change_usd_mn,
+       (latest_value_usd_mn / NULLIF(prior_year_value_usd_mn, 0) - 1) * 100
+         AS yoy_percent
+FROM paired
+ORDER BY flow_code;
+```
+
+### YTD versus prior-year YTD
+
+```sql
+WITH bilateral_series AS (
+  SELECT s.series_id,
+         f.dimension_code AS flow_code,
+         f.dimension_name AS flow
+  FROM series s
+  JOIN dimensions p ON p.series_id = s.series_id
+      AND p.dimension_type = 'partner'
+      AND p.dimension_code = '<partner_code>'
+  JOIN dimensions f ON f.series_id = s.series_id
+      AND f.dimension_type = 'flow'
+  JOIN dimensions h ON h.series_id = s.series_id
+      AND h.dimension_type = 'hs_level'
+      AND h.dimension_code = '<hs_level_code>'
+  WHERE s.dataset_code ILIKE '<dataset>'
+    AND s.measurement_units = '<value_units>'
+),
+monthly AS (
+  SELECT date_trunc('month', dp.time)::date AS month,
+         bs.flow_code,
+         bs.flow,
+         SUM(dp.value) / <unit_divisor_to_usd_mn> AS value_usd_mn
+  FROM data_points dp
+  JOIN bilateral_series bs USING (series_id)
+  GROUP BY 1, 2, 3
+),
+common_latest AS (
+  SELECT month AS latest_month
+  FROM monthly
+  GROUP BY month
+  HAVING COUNT(DISTINCT flow_code) = 2
+  ORDER BY month DESC
+  LIMIT 1
+),
+ytd AS (
+  SELECT m.flow_code,
+         m.flow,
+         EXTRACT(YEAR FROM m.month)::int AS year,
+         SUM(m.value_usd_mn) AS value_usd_mn
+  FROM monthly m
+  CROSS JOIN common_latest cl
+  WHERE EXTRACT(MONTH FROM m.month) <= EXTRACT(MONTH FROM cl.latest_month)
+    AND EXTRACT(YEAR FROM m.month) IN (
+      EXTRACT(YEAR FROM cl.latest_month),
+      EXTRACT(YEAR FROM cl.latest_month) - 1
+    )
+  GROUP BY m.flow_code, m.flow, EXTRACT(YEAR FROM m.month)
+),
+paired AS (
+  SELECT y.flow_code,
+         y.flow,
+         MAX(y.value_usd_mn) FILTER (
+           WHERE y.year = EXTRACT(YEAR FROM cl.latest_month)
+         ) AS current_ytd_usd_mn,
+         MAX(y.value_usd_mn) FILTER (
+           WHERE y.year = EXTRACT(YEAR FROM cl.latest_month) - 1
+         ) AS prior_ytd_usd_mn
+  FROM ytd y
+  CROSS JOIN common_latest cl
+  GROUP BY y.flow_code, y.flow
+)
+SELECT flow_code,
+       flow,
+       current_ytd_usd_mn,
+       prior_ytd_usd_mn,
+       current_ytd_usd_mn - prior_ytd_usd_mn AS change_usd_mn,
+       (current_ytd_usd_mn / NULLIF(prior_ytd_usd_mn, 0) - 1) * 100
+         AS yoy_percent
+FROM paired
+ORDER BY flow_code;
+```
+
+### Previous full-year totals
+
+```sql
+WITH bilateral_series AS (
+  SELECT s.series_id,
+         f.dimension_code AS flow_code,
+         f.dimension_name AS flow
+  FROM series s
+  JOIN dimensions p ON p.series_id = s.series_id
+      AND p.dimension_type = 'partner'
+      AND p.dimension_code = '<partner_code>'
+  JOIN dimensions f ON f.series_id = s.series_id
+      AND f.dimension_type = 'flow'
+  JOIN dimensions h ON h.series_id = s.series_id
+      AND h.dimension_type = 'hs_level'
+      AND h.dimension_code = '<hs_level_code>'
+  WHERE s.dataset_code ILIKE '<dataset>'
+    AND s.measurement_units = '<value_units>'
+),
+monthly AS (
+  SELECT date_trunc('month', dp.time)::date AS month,
+         bs.flow_code,
+         bs.flow,
+         SUM(dp.value) / <unit_divisor_to_usd_mn> AS value_usd_mn
+  FROM data_points dp
+  JOIN bilateral_series bs USING (series_id)
+  GROUP BY 1, 2, 3
+),
+latest AS (
+  SELECT MAX(month) AS latest_month FROM monthly
+)
+SELECT EXTRACT(YEAR FROM m.month)::int AS year,
+       m.flow_code,
+       m.flow,
+       SUM(m.value_usd_mn) AS value_usd_mn
+FROM monthly m
+CROSS JOIN latest l
+WHERE m.month < date_trunc('year', l.latest_month)
+  AND m.month >= date_trunc('year', l.latest_month) - INTERVAL '3 years'
+GROUP BY EXTRACT(YEAR FROM m.month), m.flow_code, m.flow
+ORDER BY year, flow_code;
+```
+
+### YTD product drivers by flow
+
+Use this for the driver table. It ranks the largest absolute HS-6 changes
+within each flow. Keep both positive and negative changes if they explain the
+trend.
+
+```sql
+WITH hs_series AS (
+  SELECT s.series_id,
+         f.dimension_code AS flow_code,
+         f.dimension_name AS flow,
+         c.dimension_code AS hs_code,
+         c.dimension_name AS product
+  FROM series s
+  JOIN dimensions p ON p.series_id = s.series_id
+      AND p.dimension_type = 'partner'
+      AND p.dimension_code = '<partner_code>'
+  JOIN dimensions f ON f.series_id = s.series_id
+      AND f.dimension_type = 'flow'
+  JOIN dimensions h ON h.series_id = s.series_id
+      AND h.dimension_type = 'hs_level'
+      AND h.dimension_code = '<hs_level_code>'
+  JOIN dimensions c ON c.series_id = s.series_id
+      AND c.dimension_type = 'commodity'
+  WHERE s.dataset_code ILIKE '<dataset>'
+    AND s.measurement_units = '<value_units>'
+),
+monthly_hs AS (
+  SELECT date_trunc('month', dp.time)::date AS month,
+         hs.flow_code,
+         hs.flow,
+         hs.hs_code,
+         hs.product,
+         SUM(dp.value) / <unit_divisor_to_usd_mn> AS value_usd_mn
+  FROM data_points dp
+  JOIN hs_series hs USING (series_id)
+  GROUP BY 1, 2, 3, 4, 5
+),
+common_latest AS (
+  SELECT month AS latest_month
+  FROM monthly_hs
+  GROUP BY month
+  HAVING COUNT(DISTINCT flow_code) = 2
+  ORDER BY month DESC
+  LIMIT 1
+),
+hs_ytd AS (
+  SELECT hs.flow_code,
+         hs.flow,
+         hs.hs_code,
+         hs.product,
+         EXTRACT(YEAR FROM dp.time)::int AS year,
+         SUM(dp.value) / <unit_divisor_to_usd_mn> AS value_usd_mn
+  FROM data_points dp
+  JOIN hs_series hs USING (series_id)
+  CROSS JOIN common_latest cl
+  WHERE dp.time >= date_trunc('year', cl.latest_month) - INTERVAL '1 year'
+    AND dp.time < cl.latest_month + INTERVAL '1 month'
+    AND EXTRACT(MONTH FROM dp.time) <= EXTRACT(MONTH FROM cl.latest_month)
+    AND EXTRACT(YEAR FROM dp.time) IN (
+      EXTRACT(YEAR FROM cl.latest_month),
+      EXTRACT(YEAR FROM cl.latest_month) - 1
+    )
+  GROUP BY hs.flow_code, hs.flow, hs.hs_code, hs.product,
+           EXTRACT(YEAR FROM dp.time)
+),
+paired AS (
+  SELECT h.flow_code,
+         h.flow,
+         h.hs_code,
+         h.product,
+         MAX(h.value_usd_mn) FILTER (
+           WHERE h.year = EXTRACT(YEAR FROM cl.latest_month)
+         ) AS current_ytd_usd_mn,
+         MAX(h.value_usd_mn) FILTER (
+           WHERE h.year = EXTRACT(YEAR FROM cl.latest_month) - 1
+         ) AS prior_ytd_usd_mn
+  FROM hs_ytd h
+  CROSS JOIN common_latest cl
+  GROUP BY h.flow_code, h.flow, h.hs_code, h.product
+),
+changes AS (
+  SELECT *,
+         COALESCE(current_ytd_usd_mn, 0) - COALESCE(prior_ytd_usd_mn, 0)
+           AS change_usd_mn
+  FROM paired
+),
+ranked AS (
+  SELECT *,
+         change_usd_mn
+           / NULLIF(SUM(change_usd_mn) OVER (PARTITION BY flow_code), 0)
+           AS contribution_to_net_change,
+         ROW_NUMBER() OVER (
+           PARTITION BY flow_code
+           ORDER BY ABS(change_usd_mn) DESC
+         ) AS rn
+  FROM changes
+)
+SELECT flow_code,
+       flow,
+       hs_code,
+       product,
+       current_ytd_usd_mn,
+       prior_ytd_usd_mn,
+       change_usd_mn,
+       contribution_to_net_change
+FROM ranked
+WHERE rn <= 10
+ORDER BY flow_code, ABS(change_usd_mn) DESC;
+```
+
+## Policy context
+
+Trade-policy details change, so do current-source work for the policy section.
+Use official sources where possible: trade ministries, customs authorities,
+WTO, official FTA/CEPA pages, government press releases, and published tariff
+or non-tariff measure notices. Cite those pages as `web` sources in the report
+or lineage.
+
+For broad trade-policy reports, read `bilateral-economic-policy.md` and expand
+this policy section beyond goods. Cover services, FDI/investment, active
+bilateral negotiations, standards/certification, sector investment priorities,
+and relevant third-country policy pressure, or explicitly state which
+dimensions are not available from current data and sources.
+
+For India-South Korea, check current official information on:
+
+- India-Korea CEPA status and any review or upgrade talks.
+- Tariff reductions, rules of origin, safeguard measures, anti-dumping or
+  countervailing duties, standards, certification, and other non-tariff
+  barriers.
+- Industrial and supply-chain policies that could affect electronics,
+  semiconductors, autos, steel, petrochemicals, critical minerals, batteries,
+  and intermediate inputs.
+- Whether policy could amplify the observed trend, dampen it, or mainly shift
+  product composition rather than total trade.
+
+Keep policy inference separate from measured trade data: say "policy could
+support" or "policy could weigh on" unless the data and sources directly prove
+causality.
+
+## Report and lineage requirements
+
+- Every numeric claim in the report must come from fetched data in the current
+  session.
+- Every chart/table should carry database sources for the trade datasets and
+  web sources for policy context.
+- Lineage must include the actual SQL used for each reporter schema and the
+  local computation used to normalize units, calculate YTD/YoY growth, and
+  assemble balances.
+- If only one reporter is available, still build the trend and driver sections
+  from that source, then state that mirror-statistics comparison was not
+  available from FactIQ for this pair.

--- a/references/fiscal-policy-revenue.md
+++ b/references/fiscal-policy-revenue.md
@@ -1,0 +1,162 @@
+# Fiscal Policy and Revenue Reports
+
+Use this guide for questions about government revenue, fiscal policy, tax
+receipts, non-tax receipts, revenue by taxpayer group, or whether an
+administration's tax and fiscal policy matched its campaign promises.
+
+This guide is for the full fiscal-policy concept. Do not reduce a broad
+revenue or fiscal-policy question to one aggregate tax-versus-non-tax split
+unless the user explicitly asks for only that split.
+
+## Trigger Examples
+
+- "Compare tax revenue and non-tax revenue now versus the Biden administration."
+- "How much revenue came from different income brackets?"
+- "Break down corporate taxes by company size."
+- "What are the biggest non-tax revenue sources?"
+- "Did the administration's tax policy match what it promised?"
+- "Compare fiscal policy under government A and government B."
+
+## Required Coverage
+
+A good fiscal-policy revenue report should include:
+
+- Aggregate receipts over the requested period: total receipts, tax receipts,
+  non-tax receipts, and the tax/non-tax shares of total receipts.
+- Tax composition: individual income, corporate income, payroll/social
+  insurance, excise, estate/gift, customs duties, and any country-specific
+  revenue categories available in the source data.
+- Individual-tax distribution: income brackets, AGI bands, tax-year detail, or
+  the closest official distributional series available. If the data lag the
+  current period, state the latest tax year plainly.
+- Corporate-tax distribution: corporate size, assets, receipts, business-size
+  class, or the closest official segmentation available. If no official
+  corporate-size split is available in FactIQ, say so instead of implying the
+  aggregate corporation-income-tax line answers the question.
+- Non-tax revenue detail: the largest available components beneath the non-tax
+  total, not just one "miscellaneous receipts" line.
+- Policy-credibility note: whether the administration's enacted or pursued tax
+  and fiscal policy aligned with major campaign promises, kept separate from
+  the receipt-data analysis.
+- Methodology notes that explain timing mismatches among monthly budget
+  receipts, annual budget actuals, tax-return distribution data, projections,
+  and campaign-policy sources.
+
+## Data Source Ladder
+
+Start with the most direct official source for each layer:
+
+1. **Current aggregate receipts.** Use Treasury Monthly Treasury Statement
+   detail when available. For US reports, `treasury` MTS Table 1 is useful for
+   totals, and MTS Table 4 or equivalent source data is needed for receipt
+   categories and non-tax components.
+2. **Historical annual budget context.** Use CBO historical budget data for
+   annual federal revenues, outlays, deficits, and category context. Do not use
+   projections as actuals.
+3. **Individual-income distribution.** Use IRS Statistics of Income or another
+   official tax-return distribution source for income brackets/AGI bands. Label
+   tax year, fiscal year, and calendar year explicitly.
+4. **Corporate-size distribution.** Search IRS SOI, national tax authority
+   tables, or other official corporate tax datasets for size-class detail. Use
+   firm assets, receipts, income, or return-size classes only when the source
+   defines them. If unavailable, include a data-gap note.
+5. **Policy and promise context.** Use official campaign, transition,
+   legislative, budget, treasury/finance-ministry, CBO/JCT, or equivalent
+   sources. For current or political claims, verify with current official or
+   primary sources before writing the note.
+
+For non-US reports, translate this ladder to the country's official treasury,
+finance ministry, revenue authority, budget office, and tax-statistics agency.
+
+## Report Shape
+
+Use 3-5 sections for broad prompts:
+
+1. **Headline receipts.** Show total, tax, and non-tax revenue for the latest
+   period and comparison period. A bar chart usually works best.
+2. **Tax composition.** Break tax revenue into the major statutory sources. Use
+   shares and dollar amounts; show the biggest mix changes.
+3. **Who paid the tax.** Add income-bracket and corporate-size views when
+   available. If these data lag, label the latest available year and do not
+   compare them as if they were current-month data.
+4. **Non-tax sources.** Break non-tax revenue into named components. For US MTS
+   reports, split miscellaneous receipts into components such as Federal
+   Reserve earnings deposits, Universal Service Fund, and All Other when Table
+   4 exposes them.
+5. **Policy promises and credibility.** Summarize whether enacted or proposed
+   tax/fiscal policy matched campaign promises. Keep this concise, sourced, and
+   separate from the measured receipt charts.
+
+## Guardrails
+
+- Do not present a single aggregate tax-receipts line as a full tax-revenue
+  analysis when the user asks who paid or asks for brackets, sectors, or
+  company size.
+- Do not label all miscellaneous receipts as "non-tax revenue" without
+  explaining the largest components available in the source.
+- Do not silently mix monthly MTS data with annual IRS SOI data. The units and
+  timing differ; state the reporting lag.
+- Do not fill distributional gaps with guesses, public-company financials, or
+  one-off examples. If official size-class data is unavailable, say so.
+- Do not treat campaign-promise analysis as a numerical conclusion from receipt
+  data. It requires separate policy sources and should be framed as policy
+  alignment, not proof of intent.
+- If the report uses projections, budget estimates, or current-year partial
+  totals, label them as projections or partial totals in every relevant chart.
+
+## Useful Discovery Queries
+
+Use these as starting points, then inspect the returned datasets and dimensions:
+
+```text
+search_datasets(query="Monthly Treasury Statement receipts tax non-tax")
+search_datasets(query="historical budget revenues tax receipts")
+search_datasets(query="IRS Statistics of Income income tax brackets")
+search_datasets(query="IRS corporate income tax size assets receipts")
+search_series(schema="treasury", terms=["receipts"])
+search_series(schema="cbo", terms=["rev"])
+search_series(schema="irs_soi", terms=["income", "tax"])
+```
+
+For SQL exploration, start broad:
+
+```sql
+SELECT series_id, series_title, dataset_code, frequency, measurement_units
+FROM series
+WHERE series_title ILIKE '%tax%'
+   OR series_title ILIKE '%revenue%'
+   OR series_title ILIKE '%receipt%'
+LIMIT 50;
+```
+
+For dimensioned datasets, inspect available bracket or size dimensions before
+fetching data:
+
+```sql
+SELECT dimension_type, dimension_code, dimension_name, COUNT(*) AS series_count
+FROM dimensions
+WHERE dimension_type ILIKE '%income%'
+   OR dimension_type ILIKE '%bracket%'
+   OR dimension_type ILIKE '%size%'
+   OR dimension_type ILIKE '%asset%'
+GROUP BY 1, 2, 3
+ORDER BY 1, 2
+LIMIT 50;
+```
+
+## Methodology Language To Include
+
+When distributional data lag the current receipt period, say this plainly:
+
+"Current aggregate receipts come from monthly Treasury budget data. Income-
+bracket and corporate-size detail come from annual tax-return datasets, which
+lag the budget data and are not available for the current month. The report
+therefore uses the latest official distributional year for who-paid analysis
+and the latest monthly budget data for current totals."
+
+When non-tax detail is limited, say:
+
+"Non-tax revenue is not one economic source. It is a budget classification
+covering named miscellaneous receipt lines where available. Components are
+shown separately when the source reports them; otherwise the unresolved
+remainder is labeled as other miscellaneous receipts."

--- a/references/monetary-policy.md
+++ b/references/monetary-policy.md
@@ -1,0 +1,229 @@
+# Monetary-Policy Report Pattern
+
+Use this guide for broad questions about monetary policy, central-bank policy
+stance, policy implementation, transmission, liquidity operations, interest
+rate corridors, FX intervention, or cross-country monetary-policy comparisons.
+
+This guide is for the full policy concept. Do not reduce monetary policy to
+only the policy rate, inflation, unemployment, or GDP unless the user explicitly
+asks for that narrow slice.
+
+## Trigger Phrases
+
+Default to this pattern for prompts like:
+
+- "Explain the Fed's current monetary policy stance."
+- "Create a report on U.S. monetary policy over the past year."
+- "How is the central bank implementing policy?"
+- "What are current open market operations doing?"
+- "Are FX interventions sterilized?"
+- "Compare monetary policy transmission across countries."
+- "How are interest rates, reserves, and exchange rates shaping policy?"
+
+If the prompt is ambiguous, decide from wording:
+
+- **Rate-only wording**: "fed funds", "policy rate", "repo rate",
+  "bank rate", or "yield curve" can be a quick chart if the user asks only for
+  the rate path.
+- **Broad policy wording**: "monetary policy", "central-bank stance",
+  "implementation", "liquidity", "OMO", "reserve balances", "IORB",
+  "FX intervention", "sterilized", "transmission", or "financial conditions"
+  means this guide.
+
+## Minimum Coverage
+
+A good monetary-policy report should include:
+
+- The stated policy stance: target rate/range, market overnight rate, and
+  policy-meeting decisions over the requested period.
+- The operating framework: corridor, floor, reserve requirement, quantity
+  targets, exchange-rate regime, or other country-specific implementation
+  mechanism.
+- Administered rates and facilities: reserve remuneration, IORB or equivalent,
+  overnight reverse repo, standing lending/deposit facilities, discount window,
+  marginal lending/deposit rates, reserve requirements, and other tools used by
+  the central bank.
+- Open market operations and liquidity implementation: repo, reverse repo,
+  securities purchases or sales, balance-sheet runoff, bill issuance, central
+  bank deposits, reserve-draining operations, and standing facilities.
+- Balance-sheet and money-market conditions: reserves, monetary base, central
+  bank assets, ON RRP or similar facility usage, short-term money-market rates,
+  and liquidity stress indicators where available.
+- Communications and forward guidance: statements, minutes, speeches, dots or
+  projections when available, and FactIQ policy-stance series where supported.
+- Transmission and financial conditions: government yields, credit spreads,
+  lending rates, bank credit, mortgage rates, exchange rates, equity/credit
+  conditions, and inflation expectations where relevant.
+- Macro backdrop: inflation, labor market, growth, output gap, wages, or other
+  mandate-relevant indicators.
+- FX channel and intervention: exchange-rate moves, reserve changes, official
+  FX operations, intervention objectives, and whether intervention is
+  sterilized, unsterilized, unavailable, or not material for the country.
+
+## U.S. Checklist
+
+For Federal Reserve reports, do not stop at effective fed funds and Treasury
+yields. Check and discuss:
+
+1. **Policy target and market overnight rate.** Federal funds target range and
+   effective federal funds rate.
+2. **Administered rates.** IORB, ON RRP offering rate, discount/window rate,
+   and any relevant standing facility rates.
+3. **Open market operations.** Treasury/MBS holdings, balance-sheet runoff,
+   repo and reverse repo operations, ON RRP usage, standing repo facility, and
+   reserve-management operations where current data are available.
+4. **Liquidity conditions.** Reserve balances, monetary base, central-bank
+   assets, ON RRP balances, repo market rates, and short-term funding stress.
+5. **Communications.** FOMC statements, minutes, projections, speeches, and
+   FactIQ FOMC stance scores if available.
+6. **Transmission.** Treasury yields, mortgage/lending rates, credit spreads,
+   bank credit, dollar/FX conditions, and broader financial conditions.
+7. **Macro backdrop.** PCE/CPI inflation, unemployment, payrolls, wages, and
+   GDP/growth indicators.
+8. **FX intervention.** State whether official U.S. FX intervention is present
+   or material in the period. If not material or not observed, say so rather
+   than omitting the FX channel.
+
+## FX Intervention And Sterilization
+
+For countries where FX intervention is relevant, include this analysis:
+
+- Identify whether the central bank or government conducted or announced FX
+  intervention, reserve sales/purchases, swap operations, or exchange-rate
+  smoothing.
+- Distinguish direct spot intervention from forwards, swaps, derivative
+  positions, capital-flow measures, and verbal intervention.
+- Explain whether the operation was likely sterilized or unsterilized:
+  - **Sterilized intervention** offsets the domestic-liquidity effect through
+    domestic securities, central-bank bills, repos/reverse repos, deposits,
+    reserve requirements, or other liquidity-absorbing/injecting tools.
+  - **Unsterilized intervention** lets the FX operation change the monetary
+    base or reserve money.
+- Use official balance-sheet, reserve-money, OMO, and reserve-assets data where
+  available. If sterilization cannot be observed from the data, state the gap.
+- Avoid implying causality from timing alone. Say "consistent with", "could
+  have offset", or "the data do not prove sterilization" when evidence is
+  indirect.
+
+## Data Source Ladder
+
+Start with the most direct official or FactIQ source for each layer:
+
+1. **Central-bank policy and administered rates.** Search central-bank schemas
+   first (`frb` for the U.S.) for policy rates, administered rates, reserve
+   remuneration, corridor rates, and standing-facility rates. Use official
+   central-bank webpages or releases for live rates if database coverage lags.
+2. **OMO and balance sheet.** Search for central-bank assets, securities
+   holdings, reserve balances, monetary base, repo/reverse repo, ON RRP,
+   standing facilities, reserve requirements, and liquidity auctions. Use
+   current official sources when FactIQ lacks the operation-level data.
+3. **Policy communications.** Use `policy` FOMC/central-bank stance series and
+   documents when available. State coverage dates and do not generalize beyond
+   the corpus.
+4. **Financial conditions and transmission.** Use government yields, money
+   market rates, FX, credit, bank lending, mortgages, equities, and spreads
+   where available.
+5. **Macro backdrop.** Use inflation, labor, growth, and wage indicators from
+   the relevant statistical agencies.
+6. **FX intervention and reserves.** Use central-bank reserve assets, official
+   intervention releases, balance-of-payments/reserve data, and exchange-rate
+   series. For live FX rates, use market-data tools; for intervention claims,
+   prefer official sources.
+
+For non-U.S. reports, translate this ladder to the country's operating
+framework. A corridor system, exchange-rate peg, inflation-targeting regime, or
+managed float can require different charts and caveats.
+
+## Default Report Shape
+
+Use 3-5 sections depending on data availability:
+
+1. **Stance and decisions.** Show the policy target/range, market overnight
+   rate, and meeting decisions over the requested period.
+2. **Implementation tools.** Show administered rates and open market
+   operations/facilities. For the U.S., include IORB and OMO/ON RRP context.
+3. **Liquidity and balance sheet.** Show reserves, monetary base, central-bank
+   assets, securities holdings, or facility usage.
+4. **Transmission and FX.** Show yields, money-market rates, exchange rate, and
+   FX intervention/sterilization assessment where relevant.
+5. **Macro backdrop and communication.** Show inflation, labor/growth data, and
+   central-bank communications or stance scores that explain why policy moved.
+
+## Useful Discovery Queries
+
+Use these as starting points, then inspect returned datasets and dimensions:
+
+```text
+search_datasets(query="Federal Reserve interest rates IORB ON RRP OMO")
+search_datasets(query="central bank open market operations repo reverse repo")
+search_datasets(query="foreign exchange reserves intervention sterilized")
+search_series(schema="frb", terms=["federal", "funds"])
+search_series(schema="frb", terms=["interest", "reserve", "balances"])
+search_series(schema="frb", terms=["reverse", "repo"])
+search_series(schema="frb", terms=["monetary", "base"])
+search_series(schema="policy", terms=["fomc", "stance"])
+```
+
+For broad SQL exploration:
+
+```sql
+SELECT series_id, series_title, dataset_code, frequency, measurement_units
+FROM series
+WHERE series_title ILIKE '%IORB%'
+   OR series_title ILIKE '%interest on reserve%'
+   OR series_title ILIKE '%reverse repo%'
+   OR series_title ILIKE '%open market%'
+   OR series_title ILIKE '%reserve balance%'
+   OR series_title ILIKE '%monetary base%'
+LIMIT 50;
+```
+
+For FX intervention checks:
+
+```sql
+SELECT series_id, series_title, dataset_code, frequency, measurement_units
+FROM series
+WHERE series_title ILIKE '%foreign exchange%'
+   OR series_title ILIKE '%fx%'
+   OR series_title ILIKE '%reserve assets%'
+   OR series_title ILIKE '%intervention%'
+LIMIT 50;
+```
+
+## Guardrails
+
+- Do not imply that fed funds, long yields, inflation, and unemployment alone
+  are a complete monetary-policy report.
+- Do not silently omit IORB, reserve remuneration, standing facilities, OMO, or
+  FX intervention when the prompt asks for broad monetary policy.
+- Distinguish policy instruments from market outcomes and macro backdrop.
+- State whether each current operational detail came from FactIQ data, an
+  official source, or is unavailable.
+- Use current official central-bank or treasury sources for live OMO,
+  administered-rate, and FX-intervention details when database coverage lags.
+- Keep measured data, official policy statements, and analyst inference
+  separate. Do not infer intervention or sterilization solely from exchange-rate
+  movement.
+- If operation-level or intervention data are unavailable, opaque, delayed, or
+  inferred from reserves, say so plainly and explain how that limits the report.
+- For cross-country comparisons, compare operating frameworks before comparing
+  rate levels; a floor system, corridor system, peg, or managed float changes
+  which tools matter.
+
+## Methodology Language To Include
+
+When operational data are incomplete:
+
+"The report separates policy stance from policy implementation. Policy-rate and
+market-rate data are available in FactIQ; some current open market operations,
+administered rates, and FX-intervention details may require official
+central-bank sources. Where operation-level data are unavailable, the report
+labels the gap rather than treating rates and macro indicators as the full
+monetary-policy toolkit."
+
+When FX intervention cannot be confirmed:
+
+"Exchange-rate data alone do not prove intervention. The report checks official
+reserve, balance-sheet, and intervention sources where available. If
+sterilization cannot be observed, the report states that the evidence is
+insufficient rather than classifying the operation."

--- a/references/report-spec.md
+++ b/references/report-spec.md
@@ -239,3 +239,34 @@ summary.
 6. Return the `share_url`, paste the terminal previews into your reply inside a
    triple-backtick code block, and include the report's key findings. Do not
    leave the previews only in the tool result.
+
+## Specialized report patterns
+
+- **Bilateral merchandise trade.** For questions like "latest trend in trade
+  between A and B", read `bilateral-trade.md` and default to a compact report,
+  not a single latest-month chart. Include latest month, same-month YoY, YTD
+  versus prior YTD, prior full-year context, trade balance, product-driver
+  tables for both directions, policy context from current official sources, and
+  mirror-statistics caveats.
+- **Bilateral economic policy.** For broad prompts like "compare A and B trade
+  policy" or "discuss A and B's joint economic policy", read
+  `bilateral-economic-policy.md` before authoring the report. Define the full
+  concept, cover the relevant dimensions, and do not let merchandise trade
+  stand in for services, FDI/investment, tariff and non-tariff barriers,
+  bilateral talks, sector strategy, or third-country policy pressure.
+- **Monetary policy.** For questions about central-bank policy stance,
+  monetary policy over time, implementation tools, OMO, reserve liquidity,
+  transmission, FX intervention, or sterilization, read `monetary-policy.md`
+  before authoring the report. Do not stop at policy rates, inflation, and
+  unemployment: include administered rates such as IORB where relevant, current
+  open market operations or data gaps, balance-sheet and reserves context,
+  communication, transmission channels, FX intervention checks, and clear
+  sterilized/unsterilized intervention caveats.
+- **Fiscal-policy revenue.** For questions about tax revenue, non-tax revenue,
+  government receipts, revenue by income bracket or corporate size, or whether
+  a government's tax/fiscal policy matched campaign promises, read
+  `fiscal-policy-revenue.md` before authoring the report. Do not stop at an
+  aggregate tax-versus-non-tax split: include major tax sources,
+  distributional tax detail where official data exist, named non-tax
+  components, a sourced policy-promise alignment note when relevant, and clear
+  timing/data-gap caveats.

--- a/references/schemas.md
+++ b/references/schemas.md
@@ -34,6 +34,12 @@ file. Some schemas are admin-only and simply won't appear in your
 | `india_trade` | DGCI&S | Monthly imports/exports by HS commodity and partner (6- and 8-digit levels — never sum across levels) |
 | `traffic` | TomTom | Indian city traffic flow |
 
+## South Korea
+
+| Schema | Source | Coverage |
+|---|---|---|
+| `korea_trade` | Korea Customs Service (KCS) | Monthly imports/exports by HS commodity and partner (6-digit international and 10-digit national levels — never sum across levels; values are in US$ thousand and weight is stored as separate kg series) |
+
 ## Global / other
 
 | Schema | Source | Coverage |
@@ -49,12 +55,13 @@ file. Some schemas are admin-only and simply won't appear in your
 - Energy anything → `eia`
 - India macro → check BOTH `mospi` and `rbi`
 - Trade-war / commodity-flow stories → `census` + `china_customs` +
-  `india_trade` cover the same flows from each country's own books
-  (until `china_customs` data loads, the `census` mirror stands in for
-  the China side)
+  `india_trade` + `korea_trade` cover the same flows from each country's own
+  books when those reporters are in scope
 - Cross-country comparisons → `imf` / `worldbank`
 - Company-specific → `get_market_data` and `search_earnings` tools (not SQL schemas)
 
-HS trade schemas (`us_census_hs` in census, `china_customs`, `india_trade`)
-carry the same trade at multiple HS digit levels — filter to one level and
-never sum across levels.
+HS trade schemas (`us_census_hs` in census, `china_customs`, `india_trade`,
+`korea_trade`) carry the same trade at multiple HS digit levels — filter to one
+level and never sum across levels. Some reporters also store value and physical
+quantity/weight as separate series; filter value series explicitly for value
+reports.

--- a/references/sql-guide.md
+++ b/references/sql-guide.md
@@ -123,6 +123,29 @@ fragment instead:
 Never chart a single state/region as if it were the national figure. If you
 can't find the national aggregate, say so rather than substituting.
 
+## HS trade datasets
+
+For broad bilateral merchandise-trade questions, use
+`references/bilateral-trade.md`; it has the report trigger and ready SQL
+templates for monthly totals, latest-month YoY, YTD YoY, annual totals, and top
+HS product drivers.
+
+The core guardrails:
+
+- Filter with `dimensions` (`partner`, `flow`, `commodity`, `hs_level`) instead
+  of parsing series IDs.
+- Use exactly one HS level in an aggregation. HS-6 is the default for
+  cross-country comparison; national 8/10-digit lines are finer detail and must
+  not be summed with HS-6 rows.
+- Keep value and quantity/weight series separate. For example, Korea KCS has
+  value in `US$ Thousand` and weight in `kg`; a value report should filter
+  `measurement_units = 'US$ Thousand'`.
+- Normalize units before comparing reporters. For example, India DGCI&S values
+  are `US$ Million`, while Korea KCS values are `US$ Thousand`.
+- Query each reporter schema separately, then compare in local computation.
+  Mirror statistics differ because of timing, valuation, re-exports, and
+  revisions; state the reporter view explicitly.
+
 ## Pivoting to wide format
 
 Chart data wants one row per time period with one column per series. Use

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -41,7 +41,12 @@ Four output modes:
 - **Detailed report** (`share_report` tool) — summary + sections of narrative
   and charts + methodology, rendered on FactIQ's share-report page exactly like
   the in-house agent's reports, plus inline terminal previews of its charts. For
-  broad or analytical questions. See **Detailed reports** below.
+  broad or analytical questions. See **Detailed reports** below. Broad
+  bilateral trade questions such as "latest trend in trade between A and B",
+  broad bilateral economic-policy comparisons such as "compare A and B trade
+  policy", broad monetary-policy questions such as "explain the Fed's current
+  monetary policy stance", and broad fiscal-policy revenue questions default
+  here unless the user explicitly asks for only a quick chart.
 - **Bespoke local viz** (`build_viz.py`) — a self-contained HTML file you
   author freely and save locally, not published to FactIQ. Use when the answer
   needs something the ChartSpec can't express: a custom layout, a multi-panel
@@ -191,6 +196,23 @@ local visualizations**). Local-only; never calls the API.
    prefer short stems like `rare`, not `rare earth`) or exploration SQL
    (`run_sql` with `explore=true`) on the `series` and `dimensions` tables.
    For multi-source stories, actually fetch data from 2+ schemas.
+
+   For broad monetary-policy questions, read `references/monetary-policy.md`
+   before fetching; those questions need policy stance, administered rates,
+   implementation tools such as OMO and standing facilities, liquidity and
+   balance-sheet context, transmission channels, FX intervention and
+   sterilization checks, and explicit data-gap notes. For broad bilateral
+   merchandise-trade questions, read `references/bilateral-trade.md` before
+   fetching; those questions need trend comparisons, YTD/annual context,
+   product-driver tables, source caveats, and current policy context. For
+   bilateral economic-policy or trade-policy comparisons, read
+   `references/bilateral-economic-policy.md` first so the report covers the
+   whole concept, including services, FDI/investment, policy talks, barriers,
+   and relevant third-country pressure. For fiscal-policy revenue questions,
+   read `references/fiscal-policy-revenue.md` before fetching; those questions
+   need aggregate receipts, tax-source composition, distributional tax detail
+   where available, non-tax component detail, policy-promise context, and
+   explicit data-gap notes.
 
    For report-mode questions covering multiple topics, companies, or data
    sources, consider decomposing the research into parallel subagents — see
@@ -397,6 +419,34 @@ Ground rules:
   step touched in `series_refs`, not a single representative one.
 - **Don't pad.** If the data only supports one chart, publish a quick chart
   instead of inflating a report.
+- **Bilateral trade gets report structure.** Treat "latest trend in trade
+  between A and B" as a compact report unless the user explicitly asks for only
+  a quick chart. Follow `references/bilateral-trade.md`: latest month, YoY,
+  YTD, annual context, balance, product drivers for both directions, policy
+  context, and mirror-statistics caveats.
+- **Bilateral policy gets concept coverage.** Treat questions like "compare A
+  and B trade policy" or "discuss A and B's joint economic policy" as broad
+  policy reports, not goods-only trade reports. Follow
+  `references/bilateral-economic-policy.md`: define the economic concept, cover
+  relevant dimensions such as goods, services, FDI/investment, tariff and
+  non-tariff barriers, active bilateral talks, sector strategy, third-country
+  pressure, and explicit data gaps.
+- **Monetary policy gets implementation coverage.** Treat questions about a
+  central bank's policy stance, monetary policy over time, OMO, reserve
+  liquidity, policy corridors, transmission, or FX intervention as broad
+  monetary-policy reports unless the user explicitly asks for one narrow rate
+  chart. Follow `references/monetary-policy.md`: include the policy target and
+  market rate, administered rates such as IORB where relevant, OMO and standing
+  facilities, balance-sheet and reserve conditions, communications, macro
+  backdrop, FX channel, intervention/sterilization checks, and data-gap notes.
+- **Fiscal-policy revenue gets layered coverage.** Treat questions about tax
+  receipts, non-tax revenue, revenue by payer group, or tax/fiscal policy under
+  a government as broad fiscal-policy reports unless the user explicitly asks
+  for one aggregate chart. Follow `references/fiscal-policy-revenue.md`: start
+  with aggregate receipts, then add major tax sources, income-bracket and
+  corporate-size detail where official data exist, named non-tax components,
+  a sourced policy-promise alignment note when relevant, and explicit timing
+  or availability caveats.
 
 The `share_report` tool validates the report against FactIQ's real chart
 schemas server-side, stores it as a completed public run, and returns the
@@ -510,6 +560,22 @@ payload from the transcript so you never retype the rows.
 - `references/report-spec.md` — report JSON format for `share_report`:
   sections, per-chart fields, sources/lineage authoring, limits, a worked
   example.
+- `references/bilateral-trade.md` — report workflow and SQL templates for
+  country-pair trade questions: monthly totals, latest/YTD/annual comparisons,
+  HS product drivers, value-vs-quantity guardrails, source caveats, and policy
+  context.
+- `references/bilateral-economic-policy.md` — report pattern for broad
+  country-pair economic-policy and trade-policy comparisons: concept coverage,
+  services and FDI/investment checks, barriers, bilateral talks, sector
+  strategy, third-country policy pressure, and data-gap disclosure.
+- `references/monetary-policy.md` — report pattern for monetary-policy
+  questions: policy stance, administered rates, OMO and standing facilities,
+  balance-sheet and reserve liquidity, transmission channels, FX intervention
+  and sterilization checks, and operating-framework caveats.
+- `references/fiscal-policy-revenue.md` — report pattern for government
+  revenue and fiscal-policy questions: aggregate tax/non-tax receipts, tax
+  source composition, income-bracket and corporate-size distributional checks,
+  non-tax component detail, campaign-promise alignment, and data-gap caveats.
 - `references/viz-guide.md` — bespoke local HTML visualizations with
   `build_viz.py`: the assemble/render loop, the `DATA` contract, technique
   selection (ECharts/D3/Canvas/WebGL), a legibility checklist, starter recipes.


### PR DESCRIPTION
## Summary

Ports the substantive documentation and skill changes from defog-ai/factiq-codex-plugin PRs #5, #7, #9, and #11 into this repo's layout.

- Adds specialized report guides for bilateral merchandise trade, bilateral economic policy, fiscal-policy revenue, and monetary policy.
- Updates the FactIQ skill routing so broad questions default to detailed reports and point to the relevant guide before data fetching.
- Extends report, schema, and SQL guidance with specialized report patterns, Korea trade schema notes, and HS trade guardrails.

## Impact

Agents using this plugin get the same report-pattern coverage from the upstream Codex plugin PRs while preserving this repo's top-level references, scripts, assets, and terminal-preview workflow.

## Validation

- `git diff --check`
- `git diff --cached --check`