### PR TITLE
Clarify report table granularity guidance

### DIFF
--- a/references/bilateral-trade.md
+++ b/references/bilateral-trade.md
@@ -46,6 +46,14 @@ The default report shape is 3-4 sections:
 4. **Policy context and caveats.** Current trade agreement status, tariff and
    non-tariff issues, industrial/supply-chain policies, and source asymmetry.
 
+For trade-balance or deficit tables, choose row granularity by window and
+purpose, not by a categorical monthly or yearly default. Keep monthly charts
+for timing and seasonality. Monthly table rows are reasonable for shorter
+multi-year windows, roughly up to 3-5 years, when the story depends on turning
+points; for longer windows, especially 5+ years, prefer annual totals, YTD
+comparisons, latest/prior snapshots, or a few selected turning points so the
+table stays readable.
+
 ## Data workflow
 
 1. Call `get_data_catalog` first and skip schemas listed under

--- a/references/report-spec.md
+++ b/references/report-spec.md
@@ -71,6 +71,14 @@ ascending — some endpoints return reverse-chronological rows, which would
 render a backwards x-axis. Use `null` for gaps; don't drop rows. More than
 ~300 points per line renders slowly — thin to monthly/quarterly first.
 
+For table or data-excerpt row granularity, match the rows to the question and
+time window. Monthly rows can be sensible for shorter multi-year windows,
+roughly up to 3-5 years, when timing, seasonality, or turning points matter.
+For longer windows, especially 5+ years, monthly rows often make tables too
+noisy; usually summarize with annual totals, YTD comparisons, latest/prior
+snapshots, or selected turning points instead. Do not default categorically to
+monthly or yearly rows.
+
 ### Sources
 
 ```json

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -222,7 +222,12 @@ local visualizations**). Local-only; never calls the API.
    calls together (multiple tool calls in one turn). Use `get_series` for 1–2
    known ids; `run_sql` with a CASE-WHEN pivot for 3+ series or joins. Keep
    results inside the 50-row cap — aggregate in SQL to the granularity a chart
-   actually needs.
+   actually needs. For report tables, choose row granularity by context:
+   monthly rows can work for shorter multi-year windows, roughly up to 3-5
+   years, when timing, seasonality, or turning points matter; for longer
+   windows, especially 5+ years, usually summarize with annual totals, YTD
+   comparisons, latest/prior snapshots, or selected turning points. Do not
+   default categorically to monthly or yearly rows.
 4. **Compute yourself.** YoY growth, rebasing to an index, per-capita, ratios —
    write your own Python locally on the fetched values. There is no server-side
    code interpreter in this loop.


### PR DESCRIPTION
## Summary
- Closes #34.
- Adds context-sensitive guidance for choosing monthly vs yearly row granularity in report tables and data excerpts.
- Clarifies that monthly rows can be appropriate for shorter multi-year windows when timing, seasonality, or turning points matter, while longer 5+ year windows should usually be summarized with annual totals, YTD comparisons, latest/prior snapshots, or selected turning points.
- Explicitly avoids creating a categorical preference for monthly or yearly rows.

## Why this matters
Issue #34 came from a trade-deficit report where a long monthly non-oil deficit table dumped every monthly value. That made the report noisier than necessary and buried the useful summary. The fix matters because report tables should stay readable while still preserving monthly detail when the analysis actually needs it.

## How this solves it
This PR updates the general report spec, bilateral trade report pattern, and top-level FactIQ skill guidance so report authors choose granularity from the user's request, the time window, and the analytical point instead of source frequency alone.

## Validation
- Used explorer subagents to identify the right guidance files and review the final diff.
- Used a worker subagent to make the scoped docs edits.
- Ran `git diff --check`.
- Reviewed the final diff; changes are limited to documentation/guidance files.