### PR TITLE
Fix terminal legend glyphs, document auto-updates, bump to 0.10.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "author": {
     "name": "Defog"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "author": {
     "name": "Defog"
   },

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ data questions), the bundled FactIQ MCP server, and the `/factiq:ask` command:
 Then run **`/mcp`** once, pick **factiq**, and complete the browser-based
 Connect flow to authorize the tools (see below).
 
+#### Enable auto-updates
+
+So you always get the latest skill, MCP tools, and commands without
+reinstalling, turn on auto-updates for the marketplace:
+
+1. Run **`/plugin`**.
+2. Select **Marketplaces**.
+3. Select **factiq**.
+4. Toggle **auto-updates** on.
+
+Claude Code will then refresh the plugin automatically whenever this
+marketplace changes.
+
 ### Codex
 
 ```bash

--- a/scripts/term_chart.py
+++ b/scripts/term_chart.py
@@ -351,7 +351,7 @@ def render_line(
             lines.append(f"{' ' * 12}{chunk}")
     legend_parts = []
     for i, s in enumerate(series):
-        symbol = "*" if charset == "ascii" else "•"
+        symbol = points[i % len(points)]
         label = str(s.get("label") or s["key"])
         legend_parts.append(paint(f"{symbol} {label}", i, colors))
     lines.extend(pack_line(legend_parts, "  ", width))


### PR DESCRIPTION
## Summary

- **Fix terminal legend glyphs** — in `render_line`, the plot draws each series with a distinct glyph from `points` (`*o` ascii, `•◆` unicode), but the legend hardcoded `*` for every series. A two-series line chart therefore showed two `*` entries. The legend now uses the same per-series glyph as the plot, so it renders `* Revenue  o Net income`.
- **README** — add an "Enable auto-updates" subsection under Claude Code: `/plugin` → Marketplaces → factiq → toggle auto-updates on.
- **Version** — bump Claude Code and Codex plugin manifests to `0.10.4`.

## Verification

Rendered a two-series line chart and confirmed the legend now shows one `*` (Revenue) and one `o` (Net income), matching the plotted glyphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118DDq8KQAiActAad7hGqmq