### PR TITLE
Teach the skill FactIQ's new satellite data tool

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
-  "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.10.4",
+  "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and satellite-derived signals (crop fires, NO2 activity, monsoon rainfall) — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
+  "version": "0.11.0",
   "author": {
     "name": "Defog"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "author": {
     "name": "Defog"
   },

--- a/references/satellite.md
+++ b/references/satellite.md
@@ -1,0 +1,101 @@
+# Satellite data — `get_geo_data`
+
+Satellite-derived indicators that exist in no statistical warehouse, fetched
+live from the provider and aggregated over a region server-side. Use them for
+signals official statistics can't see or publish too slowly: crop burning as
+it happens, industrial activity from emissions, monsoon rainfall by state,
+heatwaves, agricultural drought.
+
+Read this before the first `get_geo_data` call in a session.
+
+## The tool
+
+```
+get_geo_data(dataset, region, start_date, end_date, aggregation="monthly")
+```
+
+Returns `{columns, results, units, region, organization, attribution,
+caveats, notes?}` — a small time series, at most 50 rows. Results are cached
+server-side, so repeating a call is cheap; the first call to an external
+provider can take 5–30 s (rainfall occasionally longer).
+
+## Datasets
+
+| dataset | measures | economic reading | history | lag |
+|---|---|---|---|---|
+| `fires_viirs` | Active-fire detections + fire radiative power (NASA FIRMS, VIIRS 375 m) | Crop-residue burning (Punjab/Haryana Oct–Nov, Indonesian burning season), deforestation fires, flaring | 2012→ | ~3 h |
+| `no2_tropomi` | Tropospheric NO₂ column, quality-filtered area mean (Sentinel-5P) | Industrial + power + traffic activity; recessions and lockdowns show up in weeks, not quarters | 2018→ | ~3 days |
+| `precip_chirps` | Rainfall, gauge-calibrated satellite (CHIRPS 0.05°) | Monsoon adequacy, drought/flood risk → food prices, rural demand, hydro | 1981→ | ~2 days prelim |
+| `temperature_power` | 2 m air temperature mean/max/min (NASA POWER, MERRA-2 0.5°) | Heatwaves → electricity demand, labour productivity, crop stress | 1981→ | ~3 days |
+| `soil_moisture_power` | Root-zone soil wetness 0–1 (NASA POWER, MERRA-2) | Sowing conditions and agricultural drought ahead of production data | 1981→ | ~3 days |
+
+## Regions
+
+- Any country: `"IND"`, `"China"`, `"Indonesia"` (ISO3 or plain name).
+- States/provinces for: **IND, CHN, IDN, VNM, THA, MYS, PHL, PAK, BGD, LKA,
+  MMR, KHM, NPL, KOR, JPN, TWN, USA** — `"India/Punjab"`, `"CHN/Guangdong"`,
+  `"USA/Texas"`. Misspellings and common variants resolve (a `notes` entry
+  says what matched); if a name can't resolve, the error lists valid names.
+- Anywhere else: `"bbox:west,south,east,north"` in degrees.
+
+The response's `region.resolved` echoes what was actually used — repeat it in
+your narrative so the reader knows the exact geography.
+
+## Windows and the 50-row budget
+
+At most 50 intervals per call (~4 years monthly, ~7 weeks daily). Patterns:
+
+- **Seasonal YoY** (the common ask — "Punjab stubble burning this year vs
+  last 5"): one call per season, e.g. `2021-10-01→2021-11-30`,
+  `2022-10-01→2022-11-30`, … in parallel. Don't fetch whole years to compare
+  two months.
+- **Long trends**: split at the 50-month boundary (e.g. 2018–2021, 2022–2025)
+  and stitch.
+- **`fires_viirs` is additionally capped at 3 years per call** (the provider
+  serves 5-day chunks); seasonal calls sidestep this entirely.
+- Daily grain is for event windows (a flood week, a heatwave fortnight), not
+  long ranges.
+
+## Reading the results honestly
+
+- **`no2_tropomi`: check `valid_obs_share` on every row.** It is the share of
+  pixels with a valid quality-filtered retrieval. Below ~0.2 the mean rests on
+  a handful of clear-sky days — say so if you use it. Fully clouded months
+  (South Asian monsoon: typically Jun–Sep) are **omitted from results** and
+  named in `notes`; never interpolate through them silently.
+- `fires_viirs` counts overpass detections, not fires put out — cloud cover
+  suppresses counts; compare like-for-like seasons, and prefer `total_frp_mw`
+  when arguing intensity rather than frequency.
+- `precip_chirps` recent days are preliminary and revised in the final
+  monthly product (~3rd week of the following month).
+- POWER datasets are 0.5° reanalysis — honest at state/country scale, blind to
+  city microclimates. Very small or very large regions sample the centroid
+  cell (a `notes` entry appears for large ones).
+- `notes` can also report partially failed fetches ("may undercount — retry").
+  Retry once before using such a result.
+
+## Attribution
+
+Every response carries an `attribution` string — put it in the chart/report
+`sources`, exactly as given. The Copernicus one ("Contains modified Copernicus
+Sentinel-5P data…") is a licence requirement, not a courtesy.
+
+## What this tool is not
+
+- No nighttime lights yet (no provider offers hosted aggregation; a
+  precomputed series is planned — check the catalog before assuming).
+- No NDVI/crop-condition index yet (planned via the same Copernicus API).
+- Not a mapping tool: results are regional aggregates, not rasters or tiles.
+- For anything already in the warehouse (official rainfall indices, IMD data,
+  electricity output), prefer the curated series — satellite data complements
+  statistics, it doesn't replace them.
+
+## Worked example — "Is Punjab's stubble burning worse this year?"
+
+1. Current season: `get_geo_data("fires_viirs", "India/Punjab",
+   "2025-10-01", "2025-11-30")`.
+2. Prior seasons (parallel calls): same window for 2021–2024.
+3. Compare `fire_detections` totals and `total_frp_mw`; note the season peaks
+   in early November — a mid-October read is premature.
+4. Chart monthly bars per year; cite "NASA FIRMS, VIIRS 375m active fire
+   detections (S-NPP)".

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -5,9 +5,13 @@ description: >
   (worlddb): US indicators (BLS employment/CPI, BEA GDP, Census trade, EIA
   energy, USDA ERS, BTS transport), international data (China NBS, China
   customs, India MOSPI/RBI/trade, Singapore, IMF, World Bank), stock quotes
-  and fundamentals, commodities/forex, and earnings-call intelligence. Use
+  and fundamentals, commodities/forex, earnings-call intelligence, and
+  satellite-derived signals (fire detections/crop burning, NO2 industrial
+  activity, monsoon rainfall, heatwaves, soil moisture — by country, state, or
+  bounding box). Use
   when the user asks about unemployment, inflation, GDP, trade flows, energy,
-  wages, markets, or wants a shareable economic chart, a terminal chart preview,
+  wages, markets, stubble burning, air quality, monsoon or drought conditions,
+  or wants a shareable economic chart, a terminal chart preview,
   a full multi-section research report, or a bespoke custom visualization or
   dashboard saved as a local HTML file. You orchestrate the whole analysis
   yourself — discover series, query SQL, compute, then publish a single chart or
@@ -103,6 +107,7 @@ All FactIQ tools are MCP tools provided by the `factiq` MCP server.
 | `run_sql` (`schema`, `sql`, `question?`, `explore?`, `auto_retry?`) | Read-only SELECT against one schema. The power tool for joins, pivots, aggregation. |
 | `get_series` (`schema`, `series_id`, `from_year?`, `to_year?`) | Fetch one series — timeseries, tabular, or `COMPOUND::` ids all work. |
 | `get_market_data` (`function`, `symbol?`, `interval?`, `outputsize?`) | Quotes, daily/weekly/monthly series, fundamentals (OVERVIEW, INCOME_STATEMENT, EARNINGS), FX, commodities (WTI, BRENT, GOLD), SYMBOL_SEARCH. |
+| `get_geo_data` (`dataset`, `region`, `start_date`, `end_date`, `aggregation?`) | Satellite-derived signals with no warehouse series: `fires_viirs` (crop burning, ~3h lag), `no2_tropomi` (industrial-activity proxy), `precip_chirps` (rainfall), `temperature_power`, `soil_moisture_power` — aggregated over a country, state (`"India/Punjab"`), or bbox. **Read `references/satellite.md` before first use** — it covers windows (max 50 intervals), the `valid_obs_share` rule, and attribution. |
 | `search_earnings` (`query`, `search_target?`, `company_filter?`, `quarter_filter?`, `limit?`) | Full-text search over earnings-call intelligence. |
 | `get_style_guides` (`guides`) | FactIQ's house-style chart/report/SQL guides (`"chart"`, `"report"`, `"sql"`, or `"all"`). Optional; this skill's `references/` already cover the **publishing** JSON formats — use these guides for extra house-style detail. |
 
@@ -232,7 +237,14 @@ local visualizations**). Local-only; never calls the API.
    code interpreter in this loop.
 5. **Recent market data.** The DB lags for very recent market/price data — use
    `get_market_data` for current quotes, commodities, and FX.
-6. **Publish, render, or build.** Quick-chart mode: build a ChartSpec object
+6. **Satellite signals.** For crop burning, air-quality-based activity,
+   monsoon rainfall, heatwaves, or agricultural drought — signals no
+   statistical agency publishes fast — use `get_geo_data`. Read
+   `references/satellite.md` first: it covers the five datasets, region
+   syntax, the 50-interval window budget (seasonal comparisons = one call
+   per season), cloud-cover caveats, and required attribution. Satellite
+   data complements warehouse series; prefer curated series where both exist.
+7. **Publish, render, or build.** Quick-chart mode: build a ChartSpec object
    (see `references/chart-spec.md`) with wide-format data rows, save it to JSON,
    call `share_chart`, then run `term_chart.py render`; return the `share_url`
    and paste the terminal preview into your reply inside a triple-backtick code
@@ -580,6 +592,9 @@ payload from the transcript so you never retype the rows.
   revenue and fiscal-policy questions: aggregate tax/non-tax receipts, tax
   source composition, income-bracket and corporate-size distributional checks,
   non-tax component detail, campaign-promise alignment, and data-gap caveats.
+- `references/satellite.md` — the `get_geo_data` satellite tool: datasets and
+  their economic reading, region syntax and coverage, window budgeting,
+  cloud/quality caveats, attribution requirements, worked example.
 - `references/viz-guide.md` — bespoke local HTML visualizations with
   `build_viz.py`: the assemble/render loop, the `DATA` contract, technique
   selection (ECharts/D3/Canvas/WebGL), a legibility checklist, starter recipes.


### PR DESCRIPTION
## What this adds

The FactIQ server is gaining a `get_geo_data` tool (companion PR: defog-ai/worlddb — "Add a satellite data tool") that returns satellite-derived indicators aggregated over a country, state, or bounding box: active fires (crop burning), NO₂ air pollution as an industrial-activity proxy, rainfall, temperature, and soil moisture.

This PR teaches the plugin to use it well:

- **`references/satellite.md`** — a guide the skill reads before first use: what each dataset actually measures and how to read it economically, region syntax and which countries have state-level outlines, how to budget the 50-rows-per-call window (seasonal comparisons = one call per season), the cloud-cover honesty rules (never interpolate through satellite-blind monsoon months; check the valid-observation share before leaning on an air-quality number), and the attribution strings that must appear in published charts and reports.
- **`SKILL.md`** — adds the tool to the tool table and the orchestration workflow, and widens the skill description so questions about stubble burning, air quality, monsoon or drought conditions trigger it.
- Version bump to 0.11.0.

No script or command changes — the tool arrives through the same MCP connection as everything else.