### PR TITLE
Teach the skill the new data: shipping activity, nighttime lights, water levels, NDVI, and maps

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and satellite-derived signals (crop fires, NO2 activity, monsoon rainfall) — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "author": {
     "name": "Defog"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 config.json
 .env
 *.local.json
+.playwright-cli/

--- a/references/chart-spec.md
+++ b/references/chart-spec.md
@@ -63,7 +63,46 @@ If the claim depends on a time window, keep the range in the title.
 | `scatter` | Two metrics correlated; needs `yField` |
 | `bubble` | Scatter + a size dimension; needs `yField` + `sizeField`; no date x-axis |
 | `small_multiples` | Same metric across many entities; set `facetField` |
-| `map` | Geographic distribution; needs `mapConfig` `{visualizationType, mapId, geoKey, valueKey}` |
+| `map` | Geographic distribution; needs `mapConfig` — see **Maps** below |
+
+## Maps
+
+Use a map when geography IS the finding (divergence, concentration, spread) —
+for "top N regions" a ranked bar usually reads faster. The base fields
+(`xField`, `series`) are still required; maps additionally take `mapConfig`.
+
+Choropleth (region-shaded):
+
+```json
+{
+  "type": "map",
+  "title": "Delhi is India's brightest state at night — 24x the national mean (Jan 2024)",
+  "xField": {"key": "state", "label": "State"},
+  "series": [{"key": "radiance", "label": "Mean radiance (nW/cm²/sr)"}],
+  "data": [{"state": "Maharashtra", "radiance": 0.79}, {"state": "Delhi", "radiance": 14.5}],
+  "mapConfig": {"visualizationType": "choropleth_gradient",
+                "mapId": "countries/in/in-all",
+                "geoKey": "state", "valueKey": "radiance",
+                "valueLabel": "Mean radiance (nW/cm²/sr)", "labelKey": "state"}
+}
+```
+
+Coordinate bubbles (ports, stations, cities): `visualizationType: "bubble"`
+with `latKey`/`lonKey`/`sizeKey`, empty `geoKey`, `mapId: "custom/world"`.
+
+Rules:
+
+- `mapId`: `custom/world` (countries), `custom/europe`, `countries/us/us-all`,
+  or `countries/<cc>/<cc>-all` for in, cn, id, vn, th, my, ph, pk, bd, lk,
+  mm, kh, np, kr, jp, tw, sg (state/province level).
+- `geoKey` values can be plain names, ISO codes, or Highcharts keys —
+  `share_chart` normalizes them ("Maharashtra", "IND", "in" all work) and a
+  bad value comes back as a validation error with suggestions. If the error
+  says the map draws no feature for a region (world map: Taiwan; India map:
+  Ladakh; Philippines/Sri Lanka maps draw provinces/districts, not regions),
+  drop that row rather than renaming it.
+- One row per region — aggregate first; a region repeated across dates will
+  not animate, it just overwrites.
 
 ## Field reference
 

--- a/references/report-spec.md
+++ b/references/report-spec.md
@@ -47,7 +47,11 @@ model name.
 `chart_type`: `line | bar | table | bubble | small_multiples | stacked_area
 | map | heatmap`. **Stick to `line`, `bar`, and `table`** — they take the
 simple tabular format below. The other types pass through with the in-house
-agent's full hydrated config structure, which is not documented here.
+agent's full hydrated config structure, which is not documented here. For a
+geographic finding, publish the map as its own `share_chart` (fully supported
+— see `references/chart-spec.md`, **Maps**) and reference its share link from
+the section narrative, rather than embedding an undocumented map structure in
+the report.
 
 Tabular chart fields:
 

--- a/references/satellite.md
+++ b/references/satellite.md
@@ -87,12 +87,14 @@ Sentinel-5P data…") is a licence requirement, not a courtesy.
 
 ## What this tool is not
 
-- No nighttime lights yet (no provider offers hosted aggregation; a
-  precomputed series is planned — check the catalog before assuming).
 - Not a mapping tool: results are regional aggregates, not rasters or tiles.
-- Shipping/trade activity is NOT here — the `portwatch` SQL schema carries
-  IMF PortWatch's satellite-AIS daily series (chokepoint transits, port calls,
-  import/export estimates); see `references/schemas.md`.
+- Several satellite signals live in the WAREHOUSE instead of this tool, as
+  the `satellite` SQL schema: monthly **nighttime lights** by country/state
+  (precomputed — no hosted aggregation API exists) and **lake/reservoir water
+  levels** from radar altimetry (per-station series; search by reservoir
+  name, e.g. "srisailam"). Shipping/trade activity is the `portwatch` schema
+  (satellite-AIS chokepoint transits, port calls, import/export estimates).
+  See `references/schemas.md`.
 - For anything already in the warehouse (official rainfall indices, IMD data,
   electricity output), prefer the curated series — satellite data complements
   statistics, it doesn't replace them.

--- a/references/satellite.md
+++ b/references/satellite.md
@@ -25,6 +25,7 @@ provider can take 5–30 s (rainfall occasionally longer).
 |---|---|---|---|---|
 | `fires_viirs` | Active-fire detections + fire radiative power (NASA FIRMS, VIIRS 375 m) | Crop-residue burning (Punjab/Haryana Oct–Nov, Indonesian burning season), deforestation fires, flaring | 2012→ | ~3 h |
 | `no2_tropomi` | Tropospheric NO₂ column, quality-filtered area mean (Sentinel-5P) | Industrial + power + traffic activity; recessions and lockdowns show up in weeks, not quarters | 2018→ | ~3 days |
+| `ndvi_s2` | Vegetation index NDVI, cloud-masked area mean (Sentinel-2) | Crop condition ahead of harvest statistics — compare the same season across years (sowing → peak canopy → harvest is a normal arc, not a trend) | 2017→ | ~2–5 days |
 | `precip_chirps` | Rainfall, gauge-calibrated satellite (CHIRPS 0.05°) | Monsoon adequacy, drought/flood risk → food prices, rural demand, hydro | 1981→ | ~2 days prelim |
 | `temperature_power` | 2 m air temperature mean/max/min (NASA POWER, MERRA-2 0.5°) | Heatwaves → electricity demand, labour productivity, crop stress | 1981→ | ~3 days |
 | `soil_moisture_power` | Root-zone soil wetness 0–1 (NASA POWER, MERRA-2) | Sowing conditions and agricultural drought ahead of production data | 1981→ | ~3 days |
@@ -58,11 +59,15 @@ At most 50 intervals per call (~4 years monthly, ~7 weeks daily). Patterns:
 
 ## Reading the results honestly
 
-- **`no2_tropomi`: check `valid_obs_share` on every row.** It is the share of
-  pixels with a valid quality-filtered retrieval. Below ~0.2 the mean rests on
-  a handful of clear-sky days — say so if you use it. Fully clouded months
-  (South Asian monsoon: typically Jun–Sep) are **omitted from results** and
-  named in `notes`; never interpolate through them silently.
+- **`no2_tropomi` and `ndvi_s2`: check `valid_obs_share` on every row.** It is
+  the share of pixels with a valid, cloud-free retrieval. Below ~0.2 the mean
+  rests on a handful of clear-sky views — say so if you use it. Fully clouded
+  months (South Asian monsoon: typically Jun–Sep) are **omitted from results**
+  and named in `notes`; never interpolate through them silently.
+- `ndvi_s2` is strongly seasonal: month-over-month moves mix crop cycle with
+  weather. The honest comparison is same-month (or same-season) across years —
+  e.g. Punjab wheat peaks Jan–Feb (~0.65–0.70 NDVI); a weak peak vs prior
+  years is the signal, not the Nov→Feb climb.
 - `fires_viirs` counts overpass detections, not fires put out — cloud cover
   suppresses counts; compare like-for-like seasons, and prefer `total_frp_mw`
   when arguing intensity rather than frequency.
@@ -84,8 +89,10 @@ Sentinel-5P data…") is a licence requirement, not a courtesy.
 
 - No nighttime lights yet (no provider offers hosted aggregation; a
   precomputed series is planned — check the catalog before assuming).
-- No NDVI/crop-condition index yet (planned via the same Copernicus API).
 - Not a mapping tool: results are regional aggregates, not rasters or tiles.
+- Shipping/trade activity is NOT here — the `portwatch` SQL schema carries
+  IMF PortWatch's satellite-AIS daily series (chokepoint transits, port calls,
+  import/export estimates); see `references/schemas.md`.
 - For anything already in the warehouse (official rainfall indices, IMD data,
   electricity output), prefer the curated series — satellite data complements
   statistics, it doesn't replace them.

--- a/references/schemas.md
+++ b/references/schemas.md
@@ -48,6 +48,7 @@ file. Some schemas are admin-only and simply won't appear in your
 | `worldbank` | World Bank | Development and macro indicators by country |
 | `singstat` | Singapore Department of Statistics | Singapore national statistics |
 | `portwatch` | IMF PortWatch (satellite-AIS) | Daily shipping: transit calls + trade capacity for 28 chokepoints (Suez, Hormuz, Malacca…), port calls + import/export volume estimates for 196 countries and 2,065 ports, 2019→, ~3-day lag |
+| `satellite` | NASA / CNES satellite-derived | Monthly nighttime lights by country + state (economic-activity proxy, Asia focus, 2024→); lake & reservoir water levels from radar altimetry (650 water bodies incl. 88 Chinese, 15 major Indian reservoirs, 1990s→, per-overpass) |
 
 ## Picking schemas
 
@@ -61,6 +62,9 @@ file. Some schemas are admin-only and simply won't appear in your
 - Cross-country comparisons → `imf` / `worldbank`
 - Shipping disruptions, chokepoint transits (Suez/Hormuz/Malacca), real-time
   trade activity → `portwatch` (daily, satellite-AIS based; cite IMF PortWatch)
+- Nighttime lights (activity proxy), reservoir/lake water levels (hydropower,
+  irrigation, drought) → `satellite` schema; for on-demand fires/NO2/rainfall/
+  NDVI over arbitrary regions → the `get_geo_data` tool instead
 - Company-specific → `get_market_data` and `search_earnings` tools (not SQL schemas)
 
 HS trade schemas (`us_census_hs` in census, `china_customs`, `india_trade`,

--- a/references/schemas.md
+++ b/references/schemas.md
@@ -47,6 +47,7 @@ file. Some schemas are admin-only and simply won't appear in your
 | `imf` | International Monetary Fund | Cross-country macro indicators |
 | `worldbank` | World Bank | Development and macro indicators by country |
 | `singstat` | Singapore Department of Statistics | Singapore national statistics |
+| `portwatch` | IMF PortWatch (satellite-AIS) | Daily shipping: transit calls + trade capacity for 28 chokepoints (Suez, Hormuz, Malacca…), port calls + import/export volume estimates for 196 countries and 2,065 ports, 2019→, ~3-day lag |
 
 ## Picking schemas
 
@@ -58,6 +59,8 @@ file. Some schemas are admin-only and simply won't appear in your
   `india_trade` + `korea_trade` cover the same flows from each country's own
   books when those reporters are in scope
 - Cross-country comparisons → `imf` / `worldbank`
+- Shipping disruptions, chokepoint transits (Suez/Hormuz/Malacca), real-time
+  trade activity → `portwatch` (daily, satellite-AIS based; cite IMF PortWatch)
 - Company-specific → `get_market_data` and `search_earnings` tools (not SQL schemas)
 
 HS trade schemas (`us_census_hs` in census, `china_customs`, `india_trade`,

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -11,7 +11,8 @@ description: >
   bounding box). Use
   when the user asks about unemployment, inflation, GDP, trade flows, energy,
   wages, markets, stubble burning, air quality, monsoon or drought conditions,
-  or wants a shareable economic chart, a terminal chart preview,
+  or wants a shareable economic chart or map (country choropleths,
+  state/province choropleths, coordinate bubble maps), a terminal chart preview,
   a full multi-section research report, or a bespoke custom visualization or
   dashboard saved as a local HTML file. You orchestrate the whole analysis
   yourself — discover series, query SQL, compute, then publish a single chart or
@@ -38,7 +39,10 @@ Four output modes:
 - **Quick chart** (`share_chart` tool + `term_chart.py`) — one focused chart
   published to FactIQ as a share link, plus an inline terminal preview rendered
   from the same ChartSpec. Default for questions about a single metric or
-  comparison.
+  comparison. When geography is the finding this includes **maps**:
+  choropleths by country or state/province and coordinate bubbles — see
+  `references/chart-spec.md` (**Maps**) for the format and region-name rules
+  (the terminal preview degrades to a ranked table).
 - **Terminal chart** (`term_chart.py`) — an ANSI/ASCII preview without a share
   link. Use only when the user explicitly asks for terminal-only, ASCII-only, or
   local text output. See **Terminal charts** below.

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -107,7 +107,7 @@ All FactIQ tools are MCP tools provided by the `factiq` MCP server.
 | `run_sql` (`schema`, `sql`, `question?`, `explore?`, `auto_retry?`) | Read-only SELECT against one schema. The power tool for joins, pivots, aggregation. |
 | `get_series` (`schema`, `series_id`, `from_year?`, `to_year?`) | Fetch one series — timeseries, tabular, or `COMPOUND::` ids all work. |
 | `get_market_data` (`function`, `symbol?`, `interval?`, `outputsize?`) | Quotes, daily/weekly/monthly series, fundamentals (OVERVIEW, INCOME_STATEMENT, EARNINGS), FX, commodities (WTI, BRENT, GOLD), SYMBOL_SEARCH. |
-| `get_geo_data` (`dataset`, `region`, `start_date`, `end_date`, `aggregation?`) | Satellite-derived signals with no warehouse series: `fires_viirs` (crop burning, ~3h lag), `no2_tropomi` (industrial-activity proxy), `precip_chirps` (rainfall), `temperature_power`, `soil_moisture_power` — aggregated over a country, state (`"India/Punjab"`), or bbox. **Read `references/satellite.md` before first use** — it covers windows (max 50 intervals), the `valid_obs_share` rule, and attribution. |
+| `get_geo_data` (`dataset`, `region`, `start_date`, `end_date`, `aggregation?`) | Satellite-derived signals with no warehouse series: `fires_viirs` (crop burning, ~3h lag), `no2_tropomi` (industrial-activity proxy), `ndvi_s2` (crop condition), `precip_chirps` (rainfall), `temperature_power`, `soil_moisture_power` — aggregated over a country, state (`"India/Punjab"`), or bbox. **Read `references/satellite.md` before first use** — it covers windows (max 50 intervals), the `valid_obs_share` rule, and attribution. |
 | `search_earnings` (`query`, `search_target?`, `company_filter?`, `quarter_filter?`, `limit?`) | Full-text search over earnings-call intelligence. |
 | `get_style_guides` (`guides`) | FactIQ's house-style chart/report/SQL guides (`"chart"`, `"report"`, `"sql"`, or `"all"`). Optional; this skill's `references/` already cover the **publishing** JSON formats — use these guides for extra house-style detail. |
 
@@ -238,7 +238,7 @@ local visualizations**). Local-only; never calls the API.
 5. **Recent market data.** The DB lags for very recent market/price data — use
    `get_market_data` for current quotes, commodities, and FX.
 6. **Satellite signals.** For crop burning, air-quality-based activity,
-   monsoon rainfall, heatwaves, or agricultural drought — signals no
+   crop condition (NDVI), monsoon rainfall, heatwaves, or agricultural drought — signals no
    statistical agency publishes fast — use `get_geo_data`. Read
    `references/satellite.md` first: it covers the five datasets, region
    syntax, the 50-interval window budget (seasonal comparisons = one call


### PR DESCRIPTION
## What this adds

Documentation-only release (v0.12.0) pairing with two server changes that are already merged or in review:

- **New satellite dataset for the geo tool**: `ndvi_s2`, cloud-masked crop condition from Sentinel-2 — documented with its seasonality rule (compare the same season across years; sowing-to-harvest is an arc, not a trend). Live in production now.
- **Two new warehouse schemas** (defog-ai/worlddb#966): `portwatch` (satellite-AIS daily shipping — chokepoint transits, port calls, country import/export estimates, 2019→) and `satellite` (monthly nighttime lights by country/state; lake and reservoir water levels by name — "srisailam" is searchable). The schema guide and routing hints say which questions go where, including the boundary between warehouse schemas and the on-demand geo tool.
- **Maps as a first-class published output** (server support already merged): the chart-spec reference gains a Maps section with a worked choropleth, the coordinate-bubble variant, the seventeen supported state/province maps, the region-name rules (names, ISO codes, or keys all work — publishing normalizes and rejects with suggestions), and the basemap limits worth knowing (the world map draws no separate Taiwan; the India map shows Ladakh within Jammu and Kashmir). The skill triggers on map requests, and reports route geographic findings to a standalone shared map. Verified that the terminal preview degrades a map spec to a ranked table.