### PR TITLE
docs: correct rate limit to 10/sec, drop per-plan quota claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,5 @@ that points at the local URL.
 
 No secrets belong in this repo, and the plugin holds none — all access goes
 through the MCP server's OAuth flow, so the coding agent holds the token and
-nothing is written here. The backend enforces a 1 request/second rate limit and
-a monthly tool-call quota per plan (publishing counts against the same quota as
-the data tools).
+nothing is written here. FactIQ is currently free with no monthly usage quota;
+the backend enforces a 10 requests/second rate limit as an abuse guard.


### PR DESCRIPTION
## What

Corrects the Security section of the README to match backend reality.

## Why

The README claimed a "1 request/second rate limit and a monthly tool-call quota per plan." Both are wrong now:
- The rate limit was raised to **10 req/sec** (worlddb commit `0187b53`, 2026-06-17).
- FactIQ is currently free with a single plan and **no monthly usage quota** (quota enforcement removed from the plugin gate in defog-ai/worlddb#971).

## Change

> FactIQ is currently free with no monthly usage quota; the backend enforces a 10 requests/second rate limit as an abuse guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)