### PR TITLE
Trigger the skill on nighttime lights, water levels, and shipping questions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "factiq",
-  "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and satellite-derived signals (crop fires, NO2 activity, monsoon rainfall) — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
+  "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and satellite-derived data (nighttime lights, shipping and port activity, reservoir levels, crop fires, NO2 activity, monsoon rainfall) — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
   "version": "0.12.1",
   "author": {
     "name": "Defog"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and satellite-derived signals (crop fires, NO2 activity, monsoon rainfall) — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": {
     "name": "Defog"
   },

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -6,11 +6,15 @@ description: >
   energy, USDA ERS, BTS transport), international data (China NBS, China
   customs, India MOSPI/RBI/trade, Singapore, IMF, World Bank), stock quotes
   and fundamentals, commodities/forex, earnings-call intelligence, and
-  satellite-derived signals (fire detections/crop burning, NO2 industrial
-  activity, monsoon rainfall, heatwaves, soil moisture — by country, state, or
+  satellite-derived data: nighttime lights by country and state, lake and
+  reservoir water levels, daily shipping and port activity (chokepoint
+  transits, port calls, seaborne trade estimates), plus on-demand signals
+  (fire detections/crop burning, NO2 industrial activity, crop-condition
+  NDVI, monsoon rainfall, heatwaves, soil moisture — by country, state, or
   bounding box). Use
   when the user asks about unemployment, inflation, GDP, trade flows, energy,
   wages, markets, stubble burning, air quality, monsoon or drought conditions,
+  nighttime lights, reservoir levels, shipping or chokepoint traffic,
   or wants a shareable economic chart or map (country choropleths,
   state/province choropleths, coordinate bubble maps), a terminal chart preview,
   a full multi-section research report, or a bespoke custom visualization or
@@ -204,6 +208,10 @@ local visualizations**). Local-only; never calls the API.
    prefer short stems like `rare`, not `rare earth`) or exploration SQL
    (`run_sql` with `explore=true`) on the `series` and `dimensions` tables.
    For multi-source stories, actually fetch data from 2+ schemas.
+   Satellite-derived series live in two schemas: `portwatch` (daily shipping —
+   chokepoints, ports, country trade estimates) and `satellite` (nighttime
+   lights by state, lake/reservoir water levels) — see `references/schemas.md`
+   for routing and `references/satellite.md` for the on-demand geo tool.
 
    For broad monetary-policy questions, read `references/monetary-policy.md`
    before fetching; those questions need policy stance, administered rates,


### PR DESCRIPTION
The reference docs describe the warehouse satellite data (nighttime lights by state, lake and reservoir water levels, daily shipping and chokepoint activity), but the skill's own description — the surface that decides whether the skill activates — only mentioned the on-demand signals. Questions like "nighttime lights of Indian states" or "Srisailam reservoir level" had nothing to match on.

The description now names those datasets and their trigger words, and the discovery step in the workflow routes them to the right schemas. Version 0.12.1.