### PR TITLE
Cover the satellite warehouse data in the skill docs

### DIFF
--- a/references/schemas.md
+++ b/references/schemas.md
@@ -47,7 +47,7 @@ file. Some schemas are admin-only and simply won't appear in your
 | `imf` | International Monetary Fund | Cross-country macro indicators |
 | `worldbank` | World Bank | Development and macro indicators by country |
 | `singstat` | Singapore Department of Statistics | Singapore national statistics |
-| `portwatch` | IMF PortWatch (satellite-AIS) | Daily shipping: transit calls + trade capacity for 28 chokepoints (Suez, Hormuz, Malacca…), port calls + import/export volume estimates for 196 countries and 2,065 ports, 2019→, ~3-day lag |
+| `portwatch` | IMF PortWatch (satellite-AIS) | Daily shipping: transit calls + trade capacity for 28 chokepoints (Suez, Hormuz, Malacca…), port calls + import/export volume estimates for 196 countries and 2,065 ports, 2019→; refreshed weekly, so the latest days can be a few days to a week behind |
 | `satellite` | NASA / CNES satellite-derived | Monthly nighttime lights by country + state (economic-activity proxy, Asia focus, 2019→); lake & reservoir water levels from radar altimetry (650 water bodies incl. 88 Chinese, 15 major Indian reservoirs, 1990s→, per-overpass). Water-level stations come in two grades (`grade` dimension): `operational` updates ~weekly; `research` stations are frozen scientific archives (many end 2020-22) — always check the series `end_time` before presenting a level as current, and filter to operational for live readings |
 
 ## Picking schemas


### PR DESCRIPTION
The plugin skill now mentions the satellite-derived warehouse datasets (monthly nighttime lights and lake/reservoir water levels) so questions about them trigger the skill, and the marketplace description lists them.

Also corrects the freshness note for the IMF PortWatch shipping data: it is refreshed weekly, not ~3 days behind, so the latest days of data can trail by up to a week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)