### PR TITLE
Update the README and add an MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Defog, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,109 @@
 # FactIQ Plugin
 
-A plugin for [Claude Code](https://code.claude.com/docs/en/plugins) and
-[Codex](https://github.com/openai/codex) that lets your coding agent answer
-economic and financial data questions using FactIQ's data — catalog search,
-read-only SQL, series lookup, market data, earnings-call search — and publish
-the result as a shareable FactIQ chart or report with terminal previews, or
-build a bespoke local HTML visualization. The agent orchestrates the whole
-analysis itself; no codebase or database access is required, only a FactIQ
-account.
+Turn your coding agent into an economic-data analyst. This plugin for
+[Claude Code](https://code.claude.com/docs/en/plugins) and
+[Codex](https://github.com/openai/codex) gives the agent direct access to
+FactIQ's warehouse of official statistics — US, China, India, Korea, IMF,
+World Bank, and more — plus live market data and earnings-call intelligence.
+The agent discovers series, runs read-only SQL, computes derived metrics, and
+publishes the result as a shareable FactIQ chart or report, a terminal
+preview, or a bespoke local HTML visualization.
 
-Everything runs through the **FactIQ MCP server** (bundled in `.mcp.json`),
-which both Claude Code and Codex talk to natively over a single OAuth
-connection — discovery, fetching, and publishing alike. There is no API key to
-manage. The bundled local scripts, `term_chart.py` and `build_viz.py`, never
-touch the network.
+No codebase or database access is required — only a FactIQ account (currently
+free), authorized once over OAuth.
+
+## How it works
+
+There is no server-side agent and no black box. **Your coding agent is the
+analyst**: it decomposes the question, finds the data, does the math with its
+own tokens, authors the output, and publishes it — all through tool calls to
+the **FactIQ MCP server** (bundled in `.mcp.json`), which Claude Code and
+Codex talk to natively over a single OAuth connection.
+
+```
+┌─────────────────────────────┐
+│  Claude Code / Codex        │
+│  + factiq skill (SKILL.md)  │      the agent orchestrates everything
+└──────────────┬──────────────┘
+               │  MCP over HTTP (one OAuth connection)
+┌──────────────▼──────────────┐
+│  FactIQ MCP server          │
+│                             │
+│  discover   search_datasets, describe_dataset, search_series,
+│             get_data_catalog
+│  fetch      run_sql (read-only), get_series, get_market_data,
+│             search_earnings
+│  publish    share_chart, share_report
+└──────────────┬──────────────┘
+               │
+┌──────────────▼──────────────┐
+│  FactIQ data warehouse      │      20+ official sources, one schema
+│  + factiq.com share pages   │      published charts/reports render here
+└─────────────────────────────┘
+```
+
+A typical run:
+
+1. **Discover** — `get_data_catalog` once, then `search_datasets` /
+   `describe_dataset` / `search_series` (or exploratory SQL) to find the exact
+   series.
+2. **Fetch** — `run_sql` and `get_series`, capped at 50 rows per result by
+   design. The agent aggregates in SQL (`GROUP BY date_trunc(...)`, ratios,
+   pivots) rather than pulling raw rows — a chart only needs the aggregated
+   result anyway.
+3. **Compute** — YoY growth, rebasing, per-capita, ratios: local Python on the
+   fetched values, in the agent's own context.
+4. **Deliver** — one of four output modes:
+   - **Shareable chart** (`share_chart`) — published to factiq.com as an
+     editable, forkable share link, with an inline terminal preview.
+   - **Detailed report** (`share_report`) — a multi-section research page
+     (summary, narrative + charts, methodology, full SQL lineage) rendered on
+     factiq.com exactly like FactIQ's in-house agent produces.
+   - **Terminal chart** (`scripts/term_chart.py`) — ANSI/ASCII preview, fully
+     local.
+   - **Bespoke local viz** (`scripts/build_viz.py`) — a self-contained HTML
+     file (ECharts, D3, anything) the agent authors, screenshots headlessly,
+     and iterates on.
+
+The local scripts never touch the network; everything else flows through the
+authenticated MCP connection — including publishing, so there is no separate
+API key.
+
+## One schema, every data source
+
+The reason a single skill can query BLS unemployment, Chinese customs flows,
+RBI monetary data, and World Bank indicators with the same SQL idioms: **every
+data source in the backend is normalized into the same three core tables**,
+identical in every schema:
+
+| Table | What it holds |
+|---|---|
+| `series` | The catalog — one row per series: id, title, description, dataset, frequency, units, seasonality, geography, time coverage |
+| `data_points` | The values — `(series_id, time, value)`, indexed for fast retrieval |
+| `dimensions` | Faceted metadata — `(series_id, dimension_type, dimension_code, dimension_name)`, e.g. `partner`, `flow`, `commodity`, `hs_level` for trade data |
+
+Two auxiliary tables round out the model: `tabular_data` (JSONB rows for
+table-shaped releases that aren't clean time series) and `compound_series`
+(curated derived series with `COMPOUND::` ids).
+
+Ingestion pipelines do the hard work of flattening each source's bespoke
+format — BLS flat files, BEA APIs, customs records, RBI releases — into this
+shape, so the agent learns the model once and it works everywhere. Discovery,
+pivoting, and filtering follow the same patterns across all ~20 schemas; the
+recipes live in [`references/sql-guide.md`](references/sql-guide.md).
+
+### What's in the warehouse
+
+| Region | Schemas |
+|---|---|
+| United States | BLS (employment, CPI, JOLTS), OEWS (wages by occupation), Census (trade incl. HS-level, retail, housing), BEA (GDP, income), EIA (energy), USDA ERS, BTS (transportation), earnings-call intelligence |
+| China | NBS macro indicators, GACC customs (HS-level trade) |
+| India | MOSPI (CPI, WPI, IIP, GDP), RBI (banking, rates, forex), DGCI&S trade (HS-level), city traffic |
+| South Korea | KCS customs (HS-level trade) |
+| Global | IMF, World Bank, Singapore SingStat, live market data (quotes, fundamentals, FX, commodities) |
+
+`references/schemas.md` has the static overview; the `get_data_catalog` tool
+returns the live, authoritative version.
 
 ## Install
 
@@ -125,8 +215,6 @@ covers both data fetching and publishing.
 - `skills/factiq/SKILL.md` — the skill definition and single source of truth for
   the workflow. Auto-discovered by both Claude Code and Codex from the `skills/`
   directory
-- `AGENTS.md` — Codex project-level instructions (points to
-  `skills/factiq/SKILL.md`)
 - `commands/ask.md` — the `/factiq:ask` slash command (Claude Code)
 - `.agents/plugins/marketplace.json` — Codex marketplace entry for
   `codex plugin marketplace add defog-ai/factiq-plugin`
@@ -140,11 +228,61 @@ covers both data fetching and publishing.
   Chromium into `~/.factiq/viz-venv` on first use (no effect on your system
   Python)
 - `assets/viz-shell.html` — starting-point shell for bespoke visualizations
-- `references/` — SQL idioms, ChartSpec/report formats, monetary policy,
-  bilateral trade, bilateral economic-policy, and fiscal-policy revenue report
-  patterns, the bespoke-viz guide, and dataset schema overview
+- `references/` — SQL idioms, ChartSpec/report formats, domain playbooks
+  (monetary policy, bilateral trade, bilateral economic policy, fiscal-policy
+  revenue), the bespoke-viz guide, and dataset schema overview
 - `.claude-plugin/` — Claude Code plugin + marketplace manifests
 - `.codex-plugin/` — Codex plugin manifest
+
+## Contributing
+
+Contributions are welcome — this plugin is meant to grow with its community.
+Open an issue or a pull request.
+
+### Bespoke skills (domain playbooks) — the highest-leverage contribution
+
+The most valuable thing you can add is a **domain playbook**: a reference file
+that teaches the agent how to answer a whole class of questions well. The
+existing ones live in `references/` and are the pattern to follow:
+
+- [`references/monetary-policy.md`](references/monetary-policy.md) — central
+  bank policy stance, administered rates, OMO, balance-sheet context
+- [`references/bilateral-trade.md`](references/bilateral-trade.md) —
+  country-pair trade trends, product drivers, mirror-statistics caveats
+- [`references/bilateral-economic-policy.md`](references/bilateral-economic-policy.md)
+  — broad policy comparisons: goods, services, FDI, barriers, talks
+- [`references/fiscal-policy-revenue.md`](references/fiscal-policy-revenue.md)
+  — government receipts, tax composition, distributional detail
+
+A good playbook contains:
+
+1. **A trigger** — which question shapes it covers ("latest trend in trade
+   between A and B", "explain the Fed's stance"), wired into `SKILL.md` so the
+   agent reads the playbook *before* fetching.
+2. **Required coverage** — the dimensions a complete answer must address, so
+   the agent doesn't stop at the first obvious chart.
+3. **Ready SQL templates** — tested queries against the three-table schema for
+   the key computations (latest-month YoY, YTD comparisons, top-N drivers).
+4. **Caveats and guardrails** — unit normalization, base-year changes,
+   national-vs-subnational traps, data gaps to disclose explicitly.
+
+Ideas we'd love to see: labor-market health, inflation decomposition, energy
+markets, housing, sovereign debt, sector earnings analysis, country
+macro-risk snapshots.
+
+### Other welcome contributions
+
+- **Terminal renderers** — new chart types or better ASCII/ANSI output in
+  `scripts/term_chart.py` (keep it stdlib-only).
+- **Viz recipes** — reusable patterns for `build_viz.py` and
+  `references/viz-guide.md`.
+- **SQL idioms and pitfalls** — additions to `references/sql-guide.md` from
+  real usage.
+- **Docs and fixes** — anything that makes the agent's first attempt land.
+
+Test a playbook by running the questions it targets end-to-end through the
+skill and checking the published output; a PR description that shows a
+before/after share link is the most convincing review material.
 
 ## Configuration
 
@@ -157,5 +295,10 @@ that points at the local URL.
 
 No secrets belong in this repo, and the plugin holds none — all access goes
 through the MCP server's OAuth flow, so the coding agent holds the token and
-nothing is written here. FactIQ is currently free with no monthly usage quota;
-the backend enforces a 10 requests/second rate limit as an abuse guard.
+nothing is written here. All SQL runs read-only against the data warehouse.
+FactIQ is currently free with no monthly usage quota; the backend enforces a
+10 requests/second rate limit as an abuse guard.
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

- Rewrite the README for an open-source audience: a **How it works** section with an architecture diagram (coding agent + skill → FactIQ MCP server over one OAuth connection → warehouse + factiq.com share pages), the four-step analysis flow, and the four output modes
- Document the backend standardization: every data source is normalized into the same **three core tables** (`series`, `data_points`, `dimensions`, plus `tabular_data`/`compound_series` as auxiliary), verified against `worlddb_schema.sql`
- Add a compact warehouse-coverage table (US, China, India, Korea, global)
- Add a **Contributing** section that positions domain playbooks (the `references/` pattern: monetary policy, bilateral trade, …) as the highest-leverage community contribution, with the anatomy of a good playbook and ideas we'd welcome
- Add an **MIT LICENSE** (Defog, Inc.) and a License section
- Drop the stale `AGENTS.md` bullet from Contents (the file doesn't exist in the repo)

Install, Authentication, and Configuration sections are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pAZfrsfeccXhju35K17wf