### PR TITLE
Add explorer interview step before broad FactIQ workflows

### DIFF
--- a/commands/ask.md
+++ b/commands/ask.md
@@ -40,6 +40,12 @@ single chart could plausibly satisfy it — use the AskUserQuestion tool to
 offer the two modes, noting that the report takes noticeably longer and uses
 more of their tokens and FactIQ tool quota.
 
+If the ambiguity is not chart-versus-report but scope, audience, decision
+criteria, or report/dashboard depth, run the explorer-agent interview in
+`references/report-patterns/interview-step.md` before data work. Use the
+resulting brief as downstream context; the selected report pattern still
+controls the thesis, antithesis, synthesis, and required data checks.
+
 Then follow the skill's orchestration workflow (catalog → discover → fetch →
 compute, all via the MCP tools) and finish per the mode:
 

--- a/references/report-patterns/README.md
+++ b/references/report-patterns/README.md
@@ -11,6 +11,12 @@ domain, apply the method directly — it is the playbook generator.
 pattern file **before fetching data** — the method changes what you fetch,
 not just how you write it up.
 
+**Before choosing a pattern:** if the request is vague, high-commitment, or
+could reasonably become several different reports or dashboards, run the
+explorer-agent interview in `interview-step.md` first. The interview clarifies
+scope, audience, detail level, and success criteria; then the selected pattern
+still supplies the thesis, antithesis, synthesis, and data work.
+
 **When to skip it:** quick-chart questions ("plot the fed funds rate") and
 single-value lookups. Then follow the normal workflow in SKILL.md.
 

--- a/references/report-patterns/interview-step.md
+++ b/references/report-patterns/interview-step.md
@@ -1,0 +1,82 @@
+# Explorer-Agent Interview Step
+
+Use this reference before report or dashboard generation when the user's
+request is vague, high stakes, or contains a major unresolved choice. The
+interview is a short clarification pass run by an explorer agent before data
+fetching and report construction.
+
+The explorer agent is used because it can resolve intent, audience, scope, and
+decision criteria without prematurely committing the main report workflow to a
+dataset, chart structure, or argument. It reduces wasted data work and makes
+the eventual synthesis answer the user's real decision, not merely the easiest
+interpretation of the prompt.
+
+This step does not replace the report-pattern dialectical method. After the
+interview, the selected playbook still runs thesis, antithesis, and synthesis:
+the interview clarifies the question being tested; the dialectic remains the
+method for testing it.
+
+## Activate When
+
+- The request is broad or underspecified: "analyze", "build a dashboard",
+  "what is happening", "make a report", "compare", or "evaluate".
+- Multiple materially different scopes are plausible: geography, sector,
+  time window, measure, audience, policy frame, or company universe.
+- A dashboard/report structure depends on a major product choice: KPI set,
+  refresh cadence, drilldown depth, chart density, or share/report format.
+- The answer may drive a business, policy, investment, or public-facing
+  decision and the success criterion is not stated.
+- The user asks for a comprehensive report but has not named the decision,
+  audience, or time horizon.
+
+## Skip When
+
+- The user asks for a single series, lookup, or quick chart with clear
+  variables and date range.
+- The prompt already defines audience, scope, time window, comparison set,
+  output format, and decision criterion.
+- The user explicitly says not to ask clarifying questions or requests a fast
+  best-effort answer.
+- The task is only formatting, publishing, or validating an already specified
+  report object.
+
+## Default Interview
+
+Ask only the questions needed to unblock the work. Prefer 2-4 questions; do
+not turn the interview into a survey.
+
+1. Decision: "What decision or judgment should this report/dashboard support?"
+2. Audience: "Who is the primary reader, and what do they already know?"
+3. Scope: "Which geography, entities, sectors, and time window should be in
+   bounds?"
+4. Success metric: "What would make the output useful: a recommendation, risk
+   map, trend explanation, KPI monitor, or evidence pack?"
+5. Constraints: "Are there required sources, excluded sources, publication
+   deadlines, or formatting limits?"
+
+If the user does not answer and the workflow must continue, record explicit
+assumptions and proceed with the narrowest reasonable scope.
+
+## Passing Answers Downstream
+
+Convert the interview result into a compact brief before fetching data:
+
+- `decision`: the decision or judgment the output must support.
+- `audience`: reader type and required level of explanation.
+- `scope`: geography, entities, sector, metric family, and time window.
+- `output`: report, dashboard, chart pack, or shareable artifact constraints.
+- `success_criteria`: what the synthesis must resolve or recommend.
+- `assumptions`: unanswered items and defaults used.
+
+Use the brief to choose the report pattern, data sources, chart set, and
+section structure. Then run the existing dialectical method unchanged:
+
+- Thesis: strongest surface reading for the clarified scope.
+- Antithesis: fetched contradictions and counter-checks required by the
+  selected playbook.
+- Synthesis: one claim that explains both sides and directly answers the
+  clarified decision.
+
+If interview answers conflict with a playbook's required coverage, keep the
+playbook coverage unless the user explicitly narrows the task. Disclose any
+omitted antithesis fetches as scope limits, not as silent simplifications.

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -60,7 +60,10 @@ Five output modes:
   questions in a covered domain (bilateral trade, economic policy, monetary
   policy, fiscal revenue, business formation — see
   `references/report-patterns/README.md`) default here unless the user
-  explicitly asks for only a quick chart.
+  explicitly asks for only a quick chart. If the request is vague or
+  comprehensive, run the explorer-agent interview in
+  `references/report-patterns/interview-step.md` before data work; it clarifies
+  scope without replacing the dialectical report method.
 - **Bespoke local viz** (`build_viz.py`) — a self-contained HTML file you
   author freely and save locally, not published to FactIQ. Use when the answer
   needs something the ChartSpec can't express: a custom layout, a multi-panel
@@ -196,6 +199,18 @@ local visualizations**). Local-only; never calls the API.
 
 ## Orchestration workflow
 
+0. **Interview before major forks.** If the request is broad, vague, or about
+   to become a high-commitment workflow — especially a detailed report,
+   multi-panel dashboard, bespoke visualization, or a report that could follow
+   multiple scopes — use an explorer-agent interview before fetching data or
+   spawning research subagents. Read
+   `references/report-patterns/interview-step.md` and ask only the few choices
+   that would materially change the work: detail level, audience, user context
+   or hypothesis, priority lens, required/excluded entities, and time window.
+   Pass the answers into all downstream research and assembler prompts as hard
+   context. Skip the interview for direct answers, narrow quick charts, or when
+   the user already gave clear scope, audience, and detail level. If the user
+   does not answer, proceed with the defaults in the interview guide.
 1. **Catalog first.** Call `get_data_catalog` once to get the compact
    per-schema index and the table DDL. It tells you what each schema covers,
    not every dataset. Skip schemas under `schemas_without_data`. (You rarely
@@ -220,7 +235,10 @@ local visualizations**). Local-only; never calls the API.
    fiscal-policy revenue, business formation) to a playbook of that domain's
    canonical antitheses with ready SQL. For domains without a playbook, apply
    the method directly. Either way it changes what you fetch, not just how
-   you write it up.
+   you write it up. The interview step does not replace this method: it sets
+   the user's preferred scope and audience first, then the report-pattern
+   method determines the thesis, antithesis, synthesis, and data work inside
+   that scope.
 
    For report-mode questions covering multiple topics, companies, or data
    sources, consider decomposing the research into parallel subagents — see
@@ -270,6 +288,22 @@ sources, decompose the work into parallel subagents. This does two things:
 each research thread gets a full, focused context instead of competing for
 attention in one serial pass, and the report-assembly step gets the spec
 loaded directly in its prompt so it never guesses at field names.
+
+Before spawning subagents for a broad or underspecified request, run the
+explorer-agent interview described in
+`references/report-patterns/interview-step.md` unless the user already gave
+clear scope, detail level, audience, and priority lens. Include the interview
+answers in every research-agent prompt and in the report-assembler prompt so
+the final artifact reflects the user's context instead of only the generic
+version of the question.
+
+### Explorer interview subagent
+
+Use an explorer agent for the interview step, not a research subagent. Its job
+is to clarify the decision, audience, scope, output shape, and success criteria
+and return a compact brief. It should not fetch data, choose final chart
+schemas, or publish anything. Research subagents run only after the brief and
+the relevant report pattern are known.
 
 **Do NOT use subagents** for quick-chart mode or single-topic questions — the
 overhead is not worth it. The decision point is right after step 2 of the
@@ -568,10 +602,13 @@ payload from the transcript so you never retype the rows.
   (ECharts/D3/Canvas/WebGL), a legibility checklist, starter recipes.
 
 **`references/report-patterns/`** — how to think about broad analytical
-questions. Start at `report-patterns/README.md`: it teaches the dialectical
-method (thesis → antithesis → synthesis) that every report follows and routes
-covered domains (bilateral trade, bilateral economic policy, monetary policy,
-fiscal-policy revenue, business formation, and any added later) to a playbook
-of that domain's canonical antitheses with ready SQL. For uncovered domains —
+questions. Start at `report-patterns/interview-step.md` when the request is
+vague or high-commitment; it defines the explorer-agent interview that
+clarifies scope and audience before data work. Then read
+`report-patterns/README.md`: it teaches the dialectical method (thesis →
+antithesis → synthesis) that every report follows and routes covered domains
+(bilateral trade, bilateral economic policy, monetary policy, fiscal-policy
+revenue, business formation, and any added later) to a playbook of that
+domain's canonical antitheses with ready SQL. For uncovered domains —
 investment analysis, general macro — the README shows how to apply the method
 directly.


### PR DESCRIPTION
## Summary

- Adds `references/report-patterns/interview-step.md`, a concise explorer-agent interview guide for vague or high-commitment FactIQ requests.
- Wires the interview step into `SKILL.md`, `/ask`, and the report-pattern README before major report/dashboard workflows.
- Preserves the existing report-pattern dialectical method: the interview clarifies scope, audience, and success criteria; the selected playbook still controls thesis, antithesis, synthesis, and required data checks.

Closes #53.

## Validation

- `git diff --cached --check`
- official Codex plugin validator: `validate_plugin.py /tmp/factiq-plugin-pr`
- JSON parse checks for `.codex-plugin/plugin.json` and `.mcp.json`
- Explorer and worker subagents reviewed the integration and found no blocking issues.

## Main Branch

Based on refreshed `origin/main` at `b984a91`; no merge conflicts found.
