### PR TITLE
Document text panels for published reports

### DIFF
--- a/references/output/report-spec.md
+++ b/references/output/report-spec.md
@@ -38,20 +38,22 @@ model name.
 - `summary` — required, ≤5,000 chars. Rendered as bullets, one per sentence.
 - `sections` — 1–12 (2–5 is the sweet spot). Each needs a `heading`;
   `narrative` and `charts` are optional per section, but the report as a
-  whole needs **at least one chart** and at most **16 charts total**.
+  whole needs **at least one data chart** (text panels don't count toward
+  that minimum) and at most **16 charts total**.
 - `narrative` — **plain text, no markdown**: the report page renders it
   verbatim, so `**bold**` shows literal asterisks. ≤30,000 chars.
 
 ## Charts
 
-`chart_type`: `line | bar | table | bubble | small_multiples | stacked_area
-| map | heatmap`. **Stick to `line`, `bar`, and `table`** — they take the
-simple tabular format below. The other types pass through with the in-house
-agent's full hydrated config structure, which is not documented here. For a
-geographic finding, publish the map as its own `share_chart` (fully supported
-— see `references/output/chart-spec.md`, **Maps**) and reference its share link from
-the section narrative, rather than embedding an undocumented map structure in
-the report.
+`chart_type`: `line | bar | table | text | bubble | small_multiples |
+stacked_area | map | heatmap`. **Stick to `line`, `bar`, `table`, and
+`text`** — the first three take the simple tabular format below, and `text`
+is the prose panel documented after it. The other types pass through with the
+in-house agent's full hydrated config structure, which is not documented
+here. For a geographic finding, publish the map as its own `share_chart`
+(fully supported — see `references/output/chart-spec.md`, **Maps**) and
+reference its share link from the section narrative, rather than embedding an
+undocumented map structure in the report.
 
 Tabular chart fields:
 
@@ -82,6 +84,36 @@ For longer windows, especially 5+ years, monthly rows often make tables too
 noisy; usually summarize with annual totals, YTD comparisons, latest/prior
 snapshots, or selected turning points instead. Do not default categorically to
 monthly or yearly rows.
+
+### Text panels
+
+A `text` chart is a **prose panel**: a titled block of one to a few paragraphs
+that occupies a slot in the report flow like a chart. Use it for qualitative
+content — policy context, caveats, interpretation, "what to watch" — that has
+no numbers to plot. **Never build a table whose cells are sentences**; if a
+cell wouldn't fit on one line, it isn't table data — write a text panel.
+
+| Field | Required | Notes |
+|---|---|---|
+| `chart_type` | yes | `text` |
+| `title` | yes | The takeaway, stated like a chart title |
+| `body` | yes | Plain text, ≤4,000 chars; blank lines separate paragraphs |
+| `subtitle` | no | One line of framing |
+| `sources` | recommended | Same format as chart sources |
+
+```json
+{
+  "chart_type": "text",
+  "title": "Policy easing lowers friction, but it does not explain the surge",
+  "subtitle": "What the diplomatic thaw does and does not tell us",
+  "body": "First paragraph of plain text.\n\nSecond paragraph.",
+  "sources": [{ "name": "Ministry of Commerce", "type": "web" }]
+}
+```
+
+Text panels don't satisfy the report's at-least-one-chart requirement, and
+they aren't a second narrative — keep the section `narrative` for reading the
+section's charts, and use a text panel when the prose *is* the panel.
 
 ### Sources
 

--- a/references/report-patterns/bilateral-economic-policy.md
+++ b/references/report-patterns/bilateral-economic-policy.md
@@ -139,6 +139,11 @@ specific question.
 
 ## Reporting rules
 
+- Qualitative sections — the policy map, negotiation agenda, third-country
+  pressure, and caveats — publish as `text` panels: a takeaway title plus a
+  few paragraphs (see the Text panels section of
+  `references/output/report-spec.md`). Never lay them out as a table whose
+  cells are sentences.
 - Do not imply that merchandise trade explains all trade policy unless the
   prompt asks only for goods.
 - Do not silently omit services, FDI, or investment from a trade-policy report.

--- a/references/report-patterns/bilateral-trade.md
+++ b/references/report-patterns/bilateral-trade.md
@@ -45,6 +45,10 @@ The default report shape is 3-4 sections:
    drivers unless the latest-month move is the point of the question.
 4. **Policy context and caveats.** Current trade agreement status, tariff and
    non-tariff issues, industrial/supply-chain policies, and source asymmetry.
+   Publish this section's content as a **`text` panel** (`chart_type:
+   "text"` — a title plus a few paragraphs; see the Text panels section of
+   `references/output/report-spec.md`), never as a table whose cells are
+   sentences.
 
 For trade-balance or deficit tables, choose row granularity by window and
 purpose, not by a categorical monthly or yearly default. Keep monthly charts
@@ -491,6 +495,11 @@ For India-South Korea, check current official information on:
 Keep policy inference separate from measured trade data: say "policy could
 support" or "policy could weigh on" unless the data and sources directly prove
 causality.
+
+Render the policy discussion as prose — a `text` panel with a clear takeaway
+title and a few paragraphs covering the signals, what they mean for the trade
+reading, and the caveats. Do not lay it out as an issue/signal/caveat table;
+sentence-length cells render badly and the table format adds nothing.
 
 ## Report and lineage requirements
 


### PR DESCRIPTION
## What this does

FactIQ reports published with `share_report` now support a `text` chart type — a prose panel with a title and a body of one to a few paragraphs, occupying a slot in the report like any chart. It's for qualitative content (policy context, caveats, interpretation) that has no numbers to plot.

This PR documents it:

- **`references/output/report-spec.md`** — adds `text` to the chart-type list and a "Text panels" section with the fields, limits, a JSON example, and guidance on when to use one. Also clarifies that the report-wide minimum of one chart means one *data* chart — text panels don't count toward it.
- **`references/report-patterns/bilateral-trade.md`** — the "Policy context and caveats" section of a bilateral trade report should be published as a text panel, not a table whose cells are sentences (which rendered badly).
- **`references/report-patterns/bilateral-economic-policy.md`** — same rule for that playbook's qualitative sections (policy map, negotiation agenda, third-country pressure, caveats).

## Note on merge timing

The server-side support for the `text` type needs to be live before this merges — otherwise the skill will start emitting a panel type the API rejects. Hold this until the corresponding server and report-page changes are deployed.