### PR TITLE
Document the search_earnings tool + sec schema + bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "factiq",
       "source": "./",
-      "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations."
+      "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and earnings-call intelligence — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
-  "description": "Answer economic and financial data questions with real data from FactIQ — official statistics and market data — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.14.0",
+  "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and earnings-call intelligence — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
+  "version": "0.15.0",
   "author": {
     "name": "Defog"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "author": {
     "name": "Defog"
   },

--- a/references/data/schemas.md
+++ b/references/data/schemas.md
@@ -16,6 +16,7 @@ file. Some schemas are admin-only and simply won't appear in your
 | `eia` | Energy Information Administration | Petroleum, natural gas, electricity, renewables — production, consumption, prices |
 | `ers` | USDA Economic Research Service | Agricultural and food economics |
 | `bts` | Bureau of Transportation Statistics | Transportation and freight |
+| `sec` | SEC EDGAR (~50 large-cap companies) | XBRL segment/product/geography financial detail (`sec_10k`/`sec_10q`/`sec_20f`/`sec_40f`), management's forward guidance (`sec_guidance`), and company-specific operating KPIs like ARR/RevPAR/subscribers (`sec_kpi`) — call `describe_dataset` for series-ID conventions before querying |
 | *(not a SQL schema)* | Earnings-call transcripts, decomposed into a claim graph | Management's guidance/comparisons, Q&A pressure points, and disclosure profiles — searched via the `search_earnings` tool, never SQL (the underlying `transcripts` schema has a bespoke structure and no `series` table) |
 
 ## China
@@ -58,7 +59,7 @@ file. Some schemas are admin-only and simply won't appear in your
   `india_trade` + `korea_trade` cover the same flows from each country's own
   books when those reporters are in scope
 - Cross-country comparisons → `imf` / `worldbank`
-- Company-specific → `get_market_data` and `search_earnings` tools (not SQL schemas)
+- Company-specific: consolidated quotes/fundamentals → `get_market_data` tool (not SQL); segment/product/geography detail, forward guidance, or operating KPIs (ARR, RevPAR, ...) → `sec` schema via `run_sql`; what management said live on a call → `search_earnings` tool (not SQL)
 
 HS trade schemas (`us_census_hs` in census, `china_customs`, `india_trade`,
 `korea_trade`) carry the same trade at multiple HS digit levels — filter to one

--- a/references/data/schemas.md
+++ b/references/data/schemas.md
@@ -16,7 +16,7 @@ file. Some schemas are admin-only and simply won't appear in your
 | `eia` | Energy Information Administration | Petroleum, natural gas, electricity, renewables — production, consumption, prices |
 | `ers` | USDA Economic Research Service | Agricultural and food economics |
 | `bts` | Bureau of Transportation Statistics | Transportation and freight |
-| `earnings` | Alpha Vantage / earnings calls | Earnings-call transcripts intelligence — searched via the `search_earnings` tool, not SQL |
+| *(not a SQL schema)* | Earnings-call transcripts, decomposed into a claim graph | Management's guidance/comparisons, Q&A pressure points, and disclosure profiles — searched via the `search_earnings` tool, never SQL (the underlying `transcripts` schema has a bespoke structure and no `series` table) |
 
 ## China
 

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -120,10 +120,10 @@ All FactIQ tools are MCP tools provided by the `factiq` MCP server.
 | `run_sql` (`schema`, `sql`, `question?`, `explore?`, `auto_retry?`) | Read-only SELECT against one schema. The power tool for joins, pivots, aggregation. |
 | `get_series` (`schema`, `series_id`, `from_year?`, `to_year?`) | Fetch one series — timeseries, tabular, or `COMPOUND::` ids all work. |
 | `get_market_data` (`function`, `symbol?`, `interval?`, `outputsize?`) | Quotes, daily/weekly/monthly series, fundamentals (OVERVIEW, INCOME_STATEMENT, EARNINGS), FX, commodities (WTI, BRENT, GOLD), SYMBOL_SEARCH. |
-| `search_earnings` (`query`, `search_target?`, `company_filter?`, `quarter_filter?`, `limit?`) | Full-text search over earnings-call intelligence. |
+| `search_earnings` (`query`, `search_target?`, `company_filter?`, `quarter_filter?`, `limit?`) | Trigram/keyword search over earnings-call intelligence — atomic, quote-anchored rows decomposed from live calls, never a raw transcript dump. `search_target`: `"claims"` (default — management's guidance/comparisons/quantified statements, with `direction`/`value`/`unit` where checkable), `"pressure_points"` (what analysts pressed for in Q&A and whether management confirmed/declined/deflected), or `"disclosure_profile"` (ticker-only lookup of what a company routinely discloses vs. withholds — pass the ticker via `company_filter` or `query`). Narrow with `company_filter` (ticker) / `quarter_filter` (e.g. `"FY2026Q3"`). For filed XBRL financials (income statement, balance sheet, segment detail) use `run_sql` on the `sec` schema instead — this only covers what was said live on the call. |
 | `get_style_guides` (`guides`) | FactIQ's house-style chart/report/SQL guides (`"chart"`, `"report"`, `"sql"`, or `"all"`). Optional; this skill's `references/` already cover the **publishing** JSON formats — use these guides for extra house-style detail. |
 
-Every row-returning tool (`run_sql`, `get_series`) returns **at most 50 rows**.
+Every row-returning tool (`run_sql`, `get_series`, `search_earnings`) returns **at most 50 rows**.
 When a result comes back `"truncated": true` there is more data — your move is
 to **aggregate or compute in SQL** (a `GROUP BY date_trunc(...)`, a
 SUM/AVG/rank/ratio) and fetch that, or window a single series with


### PR DESCRIPTION
## Summary

Depends on [defog-ai/worlddb#1008](https://github.com/defog-ai/worlddb/pull/1008), which implements and exposes `search_earnings` over the MCP connector for the first time. This plugin's docs already referenced `search_earnings` speculatively (the tool table, `references/data/schemas.md`, and the Codex plugin's `defaultPrompt`/`longDescription` all mentioned earnings-call search before the backend existed) — this PR fills in the real behavior now that it's live.

- `skills/factiq/SKILL.md`: expands the `search_earnings` tool-table row with the three `search_target` modes (`claims`/`pressure_points`/`disclosure_profile`), narrowing params, and the `sec`-vs-earnings-call split; adds it to the 50-row-cap callout alongside `run_sql`/`get_series`.
- `references/data/schemas.md`: fixes a stale "Alpha Vantage" attribution on the earnings-call row (that's actually the source for `get_market_data`'s `EARNINGS` function, a different thing) — it's really the `transcripts` claim-graph, not a real SQL schema.
- Bumps `.claude-plugin/plugin.json` 0.14.0 → 0.15.0 and `.codex-plugin/plugin.json` 0.12.0 → 0.13.0, and folds "earnings-call intelligence" into the shorter Claude plugin/marketplace descriptions to match the Codex plugin's existing copy.

## Test plan
- [x] All three touched JSON manifests parse (`python3 -m json.tool`)
- [x] Backend behavior verified directly against worlddb#1008 (see that PR's test plan) before writing these docs, so the tool-table description matches the real tool's parameters/response shape

## Follow-up: the `sec` schema itself was undocumented

While confirming `search_earnings`'s docs were accurate, checked whether the `sec` schema (SEC EDGAR — segment financials, forward guidance, operating KPIs) was documented anywhere in this plugin's static reference docs. It wasn't — `schemas.md` had no `sec` row at all, and the "Picking schemas" routing note only mentioned `get_market_data`/`search_earnings` for "company-specific" questions, omitting the SQL-queryable `sec` schema entirely.

- Added a `sec` row to `references/data/schemas.md` covering all three sub-areas (`sec_10k`/`sec_10q`/`sec_20f`/`sec_40f` segment detail, `sec_guidance`, `sec_kpi`) — backend-side documentation for these landed in worlddb#1008's follow-up commit.
- Rewrote the "Company-specific" bullet in "Picking schemas" to correctly route between `get_market_data` (consolidated quotes/fundamentals), `sec` via `run_sql` (segment/guidance/KPI detail), and `search_earnings` (verbatim call transcript).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRmW9FePtncWiWLocfb1eG
