### PR TITLE
Fix stale '~50 large-cap' claim for the sec schema

### DIFF
--- a/references/data/schemas.md
+++ b/references/data/schemas.md
@@ -16,7 +16,7 @@ file. Some schemas are admin-only and simply won't appear in your
 | `eia` | Energy Information Administration | Petroleum, natural gas, electricity, renewables — production, consumption, prices |
 | `ers` | USDA Economic Research Service | Agricultural and food economics |
 | `bts` | Bureau of Transportation Statistics | Transportation and freight |
-| `sec` | SEC EDGAR (~50 large-cap companies) | XBRL segment/product/geography financial detail (`sec_10k`/`sec_10q`/`sec_20f`/`sec_40f`), management's forward guidance (`sec_guidance`), and company-specific operating KPIs like ARR/RevPAR/subscribers (`sec_kpi`) — call `describe_dataset` for series-ID conventions before querying |
+| `sec` | SEC EDGAR (~950 US-listed companies with market cap ≥ $10B) | XBRL segment/product/geography financial detail (`sec_10k`/`sec_10q`/`sec_20f`/`sec_40f`), management's forward guidance (`sec_guidance`), and company-specific operating KPIs like ARR/RevPAR/subscribers (`sec_kpi`) — call `describe_dataset` for series-ID conventions before querying |
 | *(not a SQL schema)* | Earnings-call transcripts, decomposed into a claim graph | Management's guidance/comparisons, Q&A pressure points, and disclosure profiles — searched via the `search_earnings` tool, never SQL (the underlying `transcripts` schema has a bespoke structure and no `series` table) |
 
 ## China


### PR DESCRIPTION
## Summary
- `references/data/schemas.md` described the `sec` schema as covering "~50 large-cap companies." That figure was true of the original earnings-curated seed list but stale: worlddb's SEC cronjob runs with `--track-indexes` in production, expanding coverage to every US-listed company with market cap ≥ $10B (S&P 500 + Nasdaq-100 union, plus a supplemental screen) — currently ~950 companies (verified against `sec.companies` directly).
- Companion fix on the worlddb side (same stale figure lived in `dataset_catalog.py`'s `get_data_catalog` output and `agent_config.py`'s `describe_dataset('sec')` guidance — both of which this doc's "~50" phrasing was copied from): defog-ai/worlddb#1009

## Test plan
- [x] Reviewed the corrected row renders correctly in the schemas table
- [x] Cross-checked the $10B framing against `extra_universe_10b.json`'s stated inclusion criterion in worlddb

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLHWXPbo3SzwyuCMnVKeKA