### PR TITLE
Rename search_earnings to search_earnings_transcripts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "factiq",
       "source": "./",
-      "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and earnings-call intelligence — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations."
+      "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and earnings-call transcripts — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
-  "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and earnings-call intelligence — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.15.0",
+  "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and earnings-call transcripts — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
+  "version": "0.16.0",
   "author": {
     "name": "Defog"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "author": {
     "name": "Defog"
   },
@@ -19,7 +19,7 @@
   "interface": {
     "displayName": "FactIQ",
     "shortDescription": "Economic and financial data analysis",
-    "longDescription": "Use FactIQ to answer economic and financial data questions with catalog search, read-only SQL, market data, earnings-call search, shareable charts, terminal previews, reports, and bespoke local HTML visualizations.",
+    "longDescription": "Use FactIQ to answer economic and financial data questions with catalog search, read-only SQL, market data, earnings-transcript search, shareable charts, terminal previews, reports, and bespoke local HTML visualizations.",
     "developerName": "Defog",
     "category": "Finance",
     "capabilities": [

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Turn your agent into a finance and economy analyst. This plugin for
 [Claude Code](https://code.claude.com/docs/en/plugins) and
 [Codex](https://github.com/openai/codex) gives the agent direct access to
 FactIQ's warehouse of official statistics — SEC filings, US, China, India, Korea, IMF,
-World Bank, and more — plus live market data and earnings-call intelligence.
+World Bank, and more — plus live market data and earnings-call transcripts.
 The agent discovers series, runs read-only SQL on FactIQ's database, computes 
 derived metrics, and publishes the result as a shareable FactIQ chart or report, 
 a terminal preview, or a bespoke local HTML visualization.
@@ -144,7 +144,7 @@ Codex talk to natively over a single OAuth connection.
 │  discover   search_datasets, describe_dataset, search_series,
 │             get_data_catalog
 │  fetch      run_sql (read-only), get_series, get_market_data,
-│             search_earnings
+│             search_earnings_transcripts
 │  publish    share_chart, share_report
 └──────────────┬──────────────┘
                │
@@ -175,7 +175,7 @@ recipes live in [`references/data/sql-guide.md`](references/data/sql-guide.md).
 
 | Region | Schemas |
 |---|---|
-| United States | SEC filings data, BLS (employment, CPI, JOLTS, OEWS), Census (trade incl. HS-level, retail, housing), BEA (GDP, income), EIA (energy), USDA ERS, BTS (transportation), earnings-call intelligence |
+| United States | SEC filings data, BLS (employment, CPI, JOLTS, OEWS), Census (trade incl. HS-level, retail, housing), BEA (GDP, income), EIA (energy), USDA ERS, BTS (transportation), earnings-call transcripts |
 | China | NBS macro indicators, GACC customs (HS-level trade) |
 | India | MOSPI (CPI, WPI, IIP, GDP), RBI (banking, rates, forex), DGCI&S trade (HS-level), city traffic |
 | South Korea | KCS customs (HS-level trade) |

--- a/references/data/schemas.md
+++ b/references/data/schemas.md
@@ -17,7 +17,7 @@ file. Some schemas are admin-only and simply won't appear in your
 | `ers` | USDA Economic Research Service | Agricultural and food economics |
 | `bts` | Bureau of Transportation Statistics | Transportation and freight |
 | `sec` | SEC EDGAR (~950 US-listed companies with market cap ≥ $10B) | XBRL segment/product/geography financial detail (`sec_10k`/`sec_10q`/`sec_20f`/`sec_40f`), management's forward guidance (`sec_guidance`), and company-specific operating KPIs like ARR/RevPAR/subscribers (`sec_kpi`) — call `describe_dataset` for series-ID conventions before querying |
-| *(not a SQL schema)* | Earnings-call transcripts, decomposed into a claim graph | Management's guidance/comparisons, Q&A pressure points, and disclosure profiles — searched via the `search_earnings` tool, never SQL (the underlying `transcripts` schema has a bespoke structure and no `series` table) |
+| *(not a SQL schema)* | Earnings-call transcripts, decomposed into a claim graph | Management's guidance/comparisons, Q&A pressure points, and disclosure profiles — searched via the `search_earnings_transcripts` tool, never SQL (the underlying `transcripts` schema has a bespoke structure and no `series` table) |
 
 ## China
 
@@ -59,7 +59,7 @@ file. Some schemas are admin-only and simply won't appear in your
   `india_trade` + `korea_trade` cover the same flows from each country's own
   books when those reporters are in scope
 - Cross-country comparisons → `imf` / `worldbank`
-- Company-specific: consolidated quotes/fundamentals → `get_market_data` tool (not SQL); segment/product/geography detail, forward guidance, or operating KPIs (ARR, RevPAR, ...) → `sec` schema via `run_sql`; what management said live on a call → `search_earnings` tool (not SQL)
+- Company-specific: consolidated quotes/fundamentals → `get_market_data` tool (not SQL); segment/product/geography detail, forward guidance, or operating KPIs (ARR, RevPAR, ...) → `sec` schema via `run_sql`; what management said live on a call → `search_earnings_transcripts` tool (not SQL)
 
 HS trade schemas (`us_census_hs` in census, `china_customs`, `india_trade`,
 `korea_trade`) carry the same trade at multiple HS digit levels — filter to one

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -5,7 +5,7 @@ description: >
   (worlddb): US indicators (BLS employment/CPI, BEA GDP, Census trade, EIA
   energy, USDA ERS, BTS transport), international data (China NBS, China
   customs, India MOSPI/RBI/trade, Singapore, IMF, World Bank), stock quotes
-  and fundamentals, commodities/forex, and earnings-call intelligence. Use
+  and fundamentals, commodities/forex, and earnings-call transcripts. Use
   when the user asks about unemployment, inflation, GDP, trade flows, energy,
   wages, markets,
   or wants a shareable economic chart or map (country choropleths,
@@ -26,7 +26,7 @@ allowed-tools: >
 
 You are the analyst. FactIQ provides authenticated **MCP tools** for the whole
 loop — discover the data (catalog, dataset/series search, read-only SQL, series
-lookup, market data, earnings search), then publish the result (`share_chart`,
+lookup, market data, earnings-transcript search), then publish the result (`share_chart`,
 `share_report`). There is no server-side agent: you decompose the question, find
 the data with the MCP tools, do the math with your own tokens, then either
 answer directly in a sentence or author the output and publish it with a tool
@@ -120,10 +120,10 @@ All FactIQ tools are MCP tools provided by the `factiq` MCP server.
 | `run_sql` (`schema`, `sql`, `question?`, `explore?`, `auto_retry?`) | Read-only SELECT against one schema. The power tool for joins, pivots, aggregation. |
 | `get_series` (`schema`, `series_id`, `from_year?`, `to_year?`) | Fetch one series — timeseries, tabular, or `COMPOUND::` ids all work. |
 | `get_market_data` (`function`, `symbol?`, `interval?`, `outputsize?`) | Quotes, daily/weekly/monthly series, fundamentals (OVERVIEW, INCOME_STATEMENT, EARNINGS), FX, commodities (WTI, BRENT, GOLD), SYMBOL_SEARCH. |
-| `search_earnings` (`query`, `search_target?`, `company_filter?`, `quarter_filter?`, `limit?`) | Trigram/keyword search over earnings-call intelligence — atomic, quote-anchored rows decomposed from live calls, never a raw transcript dump. `search_target`: `"claims"` (default — management's guidance/comparisons/quantified statements, with `direction`/`value`/`unit` where checkable), `"pressure_points"` (what analysts pressed for in Q&A and whether management confirmed/declined/deflected), or `"disclosure_profile"` (ticker-only lookup of what a company routinely discloses vs. withholds — pass the ticker via `company_filter` or `query`). Narrow with `company_filter` (ticker) / `quarter_filter` (e.g. `"FY2026Q3"`). For filed XBRL financials (income statement, balance sheet, segment detail) use `run_sql` on the `sec` schema instead — this only covers what was said live on the call. |
+| `search_earnings_transcripts` (`query`, `search_target?`, `company_filter?`, `quarter_filter?`, `limit?`) | Trigram/keyword (not semantic) search over earnings-call transcripts — atomic, quote-anchored rows decomposed from live calls, never a raw transcript dump. Prefer short, concrete terms from a likely statement (`"HBM demand"`, `"gross margin guidance"`); an empty `query` returns the newest rows, useful with a ticker/quarter filter. `search_target`: `"claims"` (default — management's guidance/comparisons/quantified statements, with `direction`/`value`/`unit` where checkable), `"pressure_points"` (what analysts pressed for in Q&A and whether management confirmed/declined/deflected), or `"disclosure_profile"` (ticker-only lookup of what a company routinely discloses vs. withholds — pass the ticker via `company_filter` or `query`; `quarter_filter`/`limit` are ignored). Narrow with `company_filter` (ticker) / `quarter_filter` (e.g. `"FY2026Q3"`); `limit` is 1–50 (default 15). For filed XBRL financials (income statement, balance sheet, segment detail) use `run_sql` on the `sec` schema instead — this only covers what was said live on the call. |
 | `get_style_guides` (`guides`) | FactIQ's house-style chart/report/SQL guides (`"chart"`, `"report"`, `"sql"`, or `"all"`). Optional; this skill's `references/` already cover the **publishing** JSON formats — use these guides for extra house-style detail. |
 
-Every row-returning tool (`run_sql`, `get_series`, `search_earnings`) returns **at most 50 rows**.
+Every row-returning tool (`run_sql`, `get_series`, `search_earnings_transcripts`) returns **at most 50 rows**.
 When a result comes back `"truncated": true` there is more data — your move is
 to **aggregate or compute in SQL** (a `GROUP BY date_trunc(...)`, a
 SUM/AVG/rank/ratio) and fetch that, or window a single series with


### PR DESCRIPTION
## Summary

Companion to [worlddb#1055](https://github.com/defog-ai/worlddb/pull/1055) (earnings-call search released to all users) and [worlddb#1056](https://github.com/defog-ai/worlddb/pull/1056) (tool renamed to `search_earnings_transcripts`).

## What changed

- **Tool name**: every reference to `search_earnings` is now `search_earnings_transcripts` (SKILL.md tool table and 50-row-cap list, `references/data/schemas.md`, README architecture diagram).
- **Contract sync with the released tool**: the SKILL.md tool row now documents that matching is keyword/trigram (not semantic) and wants short concrete terms, that an empty `query` returns the newest rows (useful with ticker/quarter filters), that `disclosure_profile` ignores `quarter_filter`/`limit`, and that `limit` is validated 1–50 (default 15).
- **Human-facing copy**: "earnings-call intelligence" → "earnings-call transcripts" / "earnings-transcript search" in the plugin descriptions (claude + codex manifests, marketplace listing, README, SKILL.md frontmatter).
- **Versions**: `.claude-plugin/plugin.json` 0.15.0 → 0.16.0, `.codex-plugin/plugin.json` 0.13.0 → 0.14.0.

## Rollout

Merge after worlddb#1056 deploys — until then the live MCP server still exposes the tool as `search_earnings`, so a plugin release ahead of the backend would document a name that doesn't resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KioDZf27mYWCR9JEEUs7DK