### PR TITLE
Teach FactIQ to query EU Comext country trade data

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and earnings-call transcripts — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "author": {
     "name": "Defog"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "author": {
     "name": "Defog"
   },

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ recipes live in [`references/data/sql-guide.md`](references/data/sql-guide.md).
 | China | NBS macro indicators, GACC customs (HS-level trade) |
 | India | MOSPI (CPI, WPI, IIP, GDP), RBI (banking, rates, forex), DGCI&S trade (HS-level), city traffic |
 | South Korea | KCS customs (HS-level trade) |
+| European Union | Eurostat Comext monthly trade for all 27 member-state reporters, by CN8 product and partner country |
 | Global | IMF, World Bank, Singapore SingStat, live market data (quotes, fundamentals, FX, commodities) |
 
 `references/data/schemas.md` has the static overview; the `get_data_catalog` tool

--- a/references/data/schemas.md
+++ b/references/data/schemas.md
@@ -41,6 +41,20 @@ file. Some schemas are admin-only and simply won't appear in your
 |---|---|---|
 | `korea_trade` | Korea Customs Service (KCS) | Monthly imports/exports by HS commodity and partner (6-digit international and 10-digit national levels — never sum across levels; values are in US$ thousand and weight is stored as separate kg series) |
 
+## European Union
+
+| Schema | Source | Coverage |
+|---|---|---|
+| `eu_comext_<iso2>` | Eurostat Comext | One schema per EU member-state reporter; monthly imports and exports by partner and detailed CN8 product, with trade value in euros and separate weight or supplementary-quantity series |
+
+Use the reporter's lowercase ISO2 code: `eu_comext_de` for Germany,
+`eu_comext_fr` for France, and `eu_comext_nl` for the Netherlands. All 27
+reporters are available: `at`, `be`, `bg`, `hr`, `cy`, `cz`, `dk`, `ee`, `fi`,
+`fr`, `de`, `gr`, `hu`, `ie`, `it`, `lv`, `lt`, `lu`, `mt`, `nl`, `pl`, `pt`,
+`ro`, `sk`, `si`, `es`, and `se`. There is no `eu_comext` data schema. See the
+Comext section of `sql-guide.md` before querying; its large country tables need
+exact series IDs rather than dimension searches.
+
 ## Global / other
 
 | Schema | Source | Coverage |
@@ -56,8 +70,8 @@ file. Some schemas are admin-only and simply won't appear in your
 - Energy anything → `eia`
 - India macro → check BOTH `mospi` and `rbi`
 - Trade-war / commodity-flow stories → `census` + `china_customs` +
-  `india_trade` + `korea_trade` cover the same flows from each country's own
-  books when those reporters are in scope
+  `india_trade` + `korea_trade` + the relevant `eu_comext_<iso2>` schemas cover
+  the same flows from each country's own records when those reporters are in scope
 - Cross-country comparisons → `imf` / `worldbank`
 - Company-specific: consolidated quotes/fundamentals → `get_market_data` tool (not SQL); segment/product/geography detail, forward guidance, or operating KPIs (ARR, RevPAR, ...) → `sec` schema via `run_sql`; what management said live on a call → `search_earnings_transcripts` tool (not SQL)
 
@@ -66,3 +80,7 @@ HS trade schemas (`us_census_hs` in census, `china_customs`, `india_trade`,
 level and never sum across levels. Some reporters also store value and physical
 quantity/weight as separate series; filter value series explicitly for value
 reports.
+
+Comext is the exception to the normal HS discovery method: do not filter its
+`dimensions` table by value. Search `eu_comext_lookup.product_codes`, construct
+exact series IDs, and query one reporter schema at a time.

--- a/references/data/sql-guide.md
+++ b/references/data/sql-guide.md
@@ -132,8 +132,9 @@ HS product drivers.
 
 The core guardrails:
 
-- Filter with `dimensions` (`partner`, `flow`, `commodity`, `hs_level`) instead
-  of parsing series IDs.
+- For trade schemas other than Comext, filter with `dimensions` (`partner`,
+  `flow`, `commodity`, `hs_level`) instead of parsing series IDs. Comext uses
+  the indexed workflow below.
 - Use exactly one HS level in an aggregation. HS-6 is the default for
   cross-country comparison; national 8/10-digit lines are finer detail and must
   not be summed with HS-6 rows.
@@ -145,6 +146,80 @@ The core guardrails:
 - Query each reporter schema separately, then compare in local computation.
   Mirror statistics differ because of timing, valuation, re-exports, and
   revisions; state the reporter view explicitly.
+
+### Eurostat Comext country schemas
+
+Comext uses one physical schema per EU reporter, named
+`eu_comext_<lowercase ISO2>`: for example, `eu_comext_de`, `eu_comext_fr`,
+and `eu_comext_nl`. There is no `eu_comext` data schema. Each country catalog
+is large enough that title searches and dimension-value scans can reach the
+30-second SQL limit.
+
+Use these rules:
+
+- Never search or filter Comext's `dimensions` table by dimension values.
+- Search the shared `eu_comext_lookup.product_codes` table by `product_code`,
+  `product_name`, `hs2_code`, `hs4_code`, or `hs6_code`.
+  It is a complete product-code lookup, including historical codes and their
+  first and last observed dates.
+- Build exact series IDs and join them to `data_points`, whose `series_id`
+  index makes the fetch fast. The detailed ID shape is
+  `eu_comext_{M|X}_{reporter}_{partner}_{te|tm}_p1_cn8_{product_code}_{eur|kg|su}`.
+  `M` means imports and `X` exports. Reporter and partner are lowercase ISO2
+  codes. The stored trade token is `te` for extra-EU trade and `tm` for
+  member-state trade.
+- Use `_eur` for trade value, `_kg` for weight, and `_su` for supplementary
+  quantity. Never sum these metrics together.
+- For all-goods totals, use the exact `cn6_total` series instead of summing
+  every CN8 product.
+- Run one already-aggregated query per reporter schema, then combine the small
+  results locally. Do not join or union the large country tables.
+
+To inspect product mappings, qualify the shared table from any country query:
+
+```sql
+SELECT product_code, product_name, hs2_code, hs4_code, hs6_code,
+       first_observed, last_observed
+FROM eu_comext_lookup.product_codes
+WHERE product_name ILIKE '%textile%'
+ORDER BY product_code
+LIMIT 50;
+```
+
+For a broad category, keep the lookup and aggregation in the same SQL call so
+the 50-row tool limit does not truncate the CN8 code list. This tested example
+returns monthly German-reported textile imports from China in 2025. Run it
+with `schema="eu_comext_de"`:
+
+```sql
+SELECT dp.time::date AS month,
+       SUM(dp.value) AS value_eur
+FROM eu_comext_lookup.product_codes p
+JOIN data_points dp
+  ON dp.series_id =
+     'eu_comext_M_de_cn_te_p1_cn8_' || lower(p.product_code) || '_eur'
+WHERE p.hs2_code BETWEEN '50' AND '63'
+  AND p.is_numeric_cn8
+  AND p.first_observed <= DATE '2025-12-01'
+  AND p.last_observed >= DATE '2025-01-01'
+  AND dp.time >= DATE '2025-01-01'
+  AND dp.time < DATE '2026-01-01'
+GROUP BY dp.time
+ORDER BY dp.time;
+```
+
+Replace the reporter, partner, flow, trade token, dates, and HS grouping for
+the question. For one named CN8 product, construct its exact ID directly. For
+all goods, query the total series:
+
+```sql
+SELECT time::date AS month, value AS value_eur
+FROM data_points
+WHERE series_id = 'eu_comext_M_de_cn_te_p1_cn6_total_eur'
+  AND time >= DATE '2025-01-01'
+  AND time < DATE '2026-01-01'
+ORDER BY time;
+```
 
 ## Pivoting to wide format
 

--- a/references/report-patterns/bilateral-trade.md
+++ b/references/report-patterns/bilateral-trade.md
@@ -68,8 +68,11 @@ table stays readable.
    so do not try to join India and Korea, China and US, etc. in one SQL call.
    Fetch comparable aggregates from each reporter, then normalize units and
    compare locally.
-4. Use the `dimensions` table to filter partner, flow, commodity, and HS level.
-   Do not parse series IDs unless dimension filters are unavailable.
+4. For most trade schemas, use `dimensions` to filter partner, flow, commodity,
+   and HS level. Eurostat Comext is the exception: never scan its `dimensions`
+   table by value. Follow the dedicated Comext workflow in
+   `references/data/sql-guide.md`, which searches the product lookup and builds
+   exact series IDs.
 5. Use exactly one HS level per table. Use HS-6 for cross-country comparison.
    Use national 8/10-digit detail only for within-reporter detail, and never
    sum national-detail rows together with HS-6 rows.
@@ -96,6 +99,9 @@ Useful India-South Korea substitutions:
 The templates below assume a trade schema with dimensions named `partner`,
 `flow`, `commodity`, `hs_level`, and `reporter` (the structure used by
 `india_trade`, `korea_trade`, `china_customs`, and similar customs schemas).
+They do not apply to `eu_comext_*`; use the indexed Comext template in
+`references/data/sql-guide.md` instead.
+
 Replace:
 
 - `<dataset>` with the dataset code, often the same as the schema.

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -4,8 +4,9 @@ description: >
   Answer economic and financial data questions with real data from FactIQ
   (worlddb): US indicators (BLS employment/CPI, BEA GDP, Census trade, EIA
   energy, USDA ERS, BTS transport), international data (China NBS, China
-  customs, India MOSPI/RBI/trade, Singapore, IMF, World Bank), stock quotes
-  and fundamentals, commodities/forex, and earnings-call transcripts. Use
+  customs, India MOSPI/RBI/trade, EU Comext trade, Singapore, IMF, World Bank),
+  stock quotes and fundamentals, commodities/forex, and earnings-call
+  transcripts. Use
   when the user asks about unemployment, inflation, GDP, trade flows, energy,
   wages, markets,
   or wants a shareable economic chart or map (country choropleths,
@@ -224,6 +225,12 @@ local visualizations**). Local-only; never calls the API.
    prefer short stems like `rare`, not `rare earth`) or exploration SQL
    (`run_sql` with `explore=true`) on the `series` and `dimensions` tables.
    For multi-source stories, actually fetch data from 2+ schemas.
+
+   Eurostat Comext is the exception: country schemas contain millions of
+   series, so do not explore their `series` or `dimensions` tables by text or
+   dimension value. Read the **Eurostat Comext country schemas** section in
+   `references/data/sql-guide.md`; it uses the small product lookup table and
+   exact indexed series IDs.
 
    **Domain report patterns.** If the question is broad and analytical —
    policy, trade, revenue, investment analysis, "what's driving X" — read
@@ -575,7 +582,9 @@ payload from the transcript so you never retype the rows.
 - **SQL timeout** — statements are capped at 30s. Filter on indexed columns
   (`series_id`, `dataset_code`) instead of scanning titles, and never
   pattern-match `series_id` on `data_points` — resolve ids from `series` first
-  (see the pitfall in `references/data/sql-guide.md`).
+  (see the pitfall in `references/data/sql-guide.md`). For `eu_comext_*`, do
+  not retry a dimension scan; use `eu_comext_lookup.product_codes` and exact
+  IDs as described in the Comext section of that guide.
 - **Publishing validation error** — `share_chart` / `share_report` validate the
   payload against FactIQ's real chart schemas and return a tool error naming the
   failing field paths (e.g. `sections[1].charts[0].x_column`). Fix the named


### PR DESCRIPTION
FactIQ exposes Eurostat Comext in one schema per EU member-state reporter. The existing plugin documentation covers other customs sources and tells agents to search the dimensions table, but that search is too expensive for the much larger Comext country catalogs.

This change documents all 27 country schema names and adds a dedicated Comext query workflow. Agents search the complete product-code lookup, construct exact indexed series IDs, keep euro values separate from weight and supplementary quantities, and query each reporter separately. The guide includes working examples for a broad HS category and an all-goods total. The bilateral-trade playbook now directs Comext questions to this workflow instead of its dimension-based templates.

The README and FactIQ skill description now include EU trade coverage. The Claude plugin version moves to 0.18.0 and the Codex plugin version moves to 0.16.0.

Validation:
- plugin manifest validation passed
- FactIQ skill validation passed
- both documented SQL examples returned the expected 12 monthly rows within the 30-second query limit