### PR TITLE
Document how artifact pages should name the FactIQ connector for live data

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and earnings-call transcripts — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "author": {
     "name": "Defog"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "author": {
     "name": "Defog"
   },

--- a/references/output/viz-guide.md
+++ b/references/output/viz-guide.md
@@ -73,6 +73,46 @@ stderr," not "minor warning."
    `open /tmp/out.html`) to open it in their browser. The file is portable and
    needs only internet for its CDN libraries.
 
+## Publishing as a claude.ai Artifact with live data
+
+When the session can publish claude.ai Artifacts, a bespoke viz can go one
+step further than a static local file: the published page can call FactIQ's
+MCP tools itself via `window.claude.mcp`, with the viewer's own credentials,
+so the page refreshes from the warehouse instead of freezing at build time.
+Four rules make this work:
+
+- **Declare the capability with the viewer's connector display name — ask them
+  for it.** The artifact's capability manifest
+  (`{mcp: {servers: [{server: "<name>", tools: ["run_sql"]}]}}`) is matched
+  against the name the viewer gave the FactIQ connector when they added it in
+  claude.ai **Settings → Connectors**. That name is free text and varies per
+  user — `FactIQ`, `factiq`, or anything else. Before publishing, ask the user
+  to read the exact name out of Settings → Connectors and put that in the
+  manifest. A wrong name makes the published page prompt the viewer to add a
+  connector that "can't be found."
+- **Never use the plugin's local server name in the manifest.** Inside a
+  coding-agent session this plugin registers its MCP server locally as
+  `factiq` (tools appear as `mcp__plugin_factiq_factiq__*`). That local
+  registration is not a claude.ai connector — `plugin_factiq_factiq` or a
+  guessed variant in the manifest resolves for no viewer.
+- **Don't hardcode the name in the page's JS.** At runtime call
+  `window.claude.mcp.listTools()` and use whichever granted server exposes the
+  tool you need (e.g. `run_sql`); pass that to `callTool`. The page then works
+  regardless of what the viewer named their connector — only the manifest
+  needs the exact name.
+- **Scope minimally and degrade gracefully.** Declare only the tools the page
+  actually calls (usually just `run_sql`). Bake a static snapshot of the data
+  into the page so it renders instantly and stays useful without the
+  capability, and branch error copy on the error `code` (`needs_reauth` →
+  "reconnect the connector", `server_not_connected` → "add the connector"),
+  keeping the baked data visible.
+
+Two build differences from the local flow: artifacts enforce a strict CSP that
+blocks all external hosts, so the CDN `<script>` tags the local shell relies on
+(ECharts, D3) won't load — author artifact-bound pages with inline JS and
+hand-rolled SVG/Canvas instead. And live queries face the same 50-row cap as
+every `run_sql` call, so aggregate in SQL exactly as you would in-session.
+
 ## Saving data without retyping
 
 `build_viz` reads its data from files, but the MCP tools return their payload

--- a/references/output/viz-guide.md
+++ b/references/output/viz-guide.md
@@ -79,22 +79,19 @@ When the session can publish claude.ai Artifacts, a bespoke viz can go one
 step further than a static local file: the published page can call FactIQ's
 MCP tools itself via `window.claude.mcp`, with the viewer's own credentials,
 so the page refreshes from the warehouse instead of freezing at build time.
-Four rules make this work:
+Three rules make this work:
 
-- **Declare the capability with the viewer's connector display name — ask them
-  for it.** The artifact's capability manifest
-  (`{mcp: {servers: [{server: "<name>", tools: ["run_sql"]}]}}`) is matched
-  against the name the viewer gave the FactIQ connector when they added it in
-  claude.ai **Settings → Connectors**. That name is free text and varies per
-  user — `FactIQ`, `factiq`, or anything else. Before publishing, ask the user
-  to read the exact name out of Settings → Connectors and put that in the
-  manifest. A wrong name makes the published page prompt the viewer to add a
-  connector that "can't be found."
-- **Never use the plugin's local server name in the manifest.** Inside a
-  coding-agent session this plugin registers its MCP server locally as
-  `factiq` (tools appear as `mcp__plugin_factiq_factiq__*`). That local
-  registration is not a claude.ai connector — `plugin_factiq_factiq` or a
-  guessed variant in the manifest resolves for no viewer.
+- **Declare the capability as `factiq` and publish — don't ask first.** Use
+  `{mcp: {servers: [{server: "factiq", tools: ["run_sql"]}]}}`. The manifest
+  is matched against the display name of the viewer's FactIQ connector in
+  claude.ai **Settings → Connectors**, and `factiq` is the default name.
+  When you deliver the link, add one line: *if the page asks you to add a
+  connector it "can't find", tell me the exact name your FactIQ connector has
+  in claude.ai Settings → Connectors and I'll republish with it.* (The name
+  is free text, so a viewer may have called it something else; republishing
+  with their name at the same URL is the whole fix. Never guess variants like
+  `plugin_factiq_factiq` — that's the plugin's local tool prefix, not a
+  claude.ai connector.)
 - **Don't hardcode the name in the page's JS.** At runtime call
   `window.claude.mcp.listTools()` and use whichever granted server exposes the
   tool you need (e.g. `run_sql`); pass that to `callTool`. The page then works

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -541,6 +541,16 @@ look → fix**:
    visual. One render pass is never enough; budget two or three.
 4. Hand the user the local file path; offer `--open` to open it in a browser.
 
+If the viz will instead be published as a **claude.ai Artifact** that calls
+FactIQ live from the page (`window.claude.mcp`), read
+`references/output/viz-guide.md` (**Publishing as a claude.ai Artifact with
+live data**) first. The critical rule: the artifact's capability manifest must
+name the viewer's FactIQ connector **exactly as it appears in their claude.ai
+Settings → Connectors** — that name is user-chosen and varies, so ask the user
+for it; never put the plugin's local server name (`factiq` /
+`plugin_factiq_factiq`) in the manifest, and have the page discover the
+callable server at runtime with `listTools()` rather than hardcoding it.
+
 ## Context budget — the 50-row cap
 
 Every row-returning MCP tool (`run_sql`, `get_series`) returns **at most 50

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -544,12 +544,12 @@ look → fix**:
 If the viz will instead be published as a **claude.ai Artifact** that calls
 FactIQ live from the page (`window.claude.mcp`), read
 `references/output/viz-guide.md` (**Publishing as a claude.ai Artifact with
-live data**) first. The critical rule: the artifact's capability manifest must
-name the viewer's FactIQ connector **exactly as it appears in their claude.ai
-Settings → Connectors** — that name is user-chosen and varies, so ask the user
-for it; never put the plugin's local server name (`factiq` /
-`plugin_factiq_factiq`) in the manifest, and have the page discover the
-callable server at runtime with `listTools()` rather than hardcoding it.
+live data**) first. In short: declare the capability as `factiq` (the default
+connector name) and publish without asking; when you deliver the link, tell
+the user that if the page can't find their connector they should send you its
+exact name from claude.ai Settings → Connectors so you can republish with it.
+In the page's own JS, discover the callable server at runtime with
+`listTools()` rather than hardcoding a name.
 
 ## Context budget — the 50-row cap
 


### PR DESCRIPTION
Pages published as claude.ai Artifacts can call FactIQ live from the page itself (through `window.claude.mcp`), using the viewer's own connector credentials. We hit a real failure building one: the page's capability declaration is matched against the display name the viewer gave the FactIQ connector in claude.ai Settings → Connectors, and a name that doesn't match makes the page prompt the viewer to add a connector that "can't be found."

This adds the missing guidance, tuned for low friction:

- Declare the capability as `factiq` — the default connector name — and publish without asking the user anything upfront. When delivering the link, mention that if the page can't find their connector, they should reply with its exact name from Settings → Connectors, and republishing with that name (same URL) is the whole fix.
- In the page's own JS, discover the callable server at runtime with `listTools()` instead of hardcoding a name, so the code works no matter what the connector is called.
- Declare only the tools the page calls, keep a baked snapshot of the data so the page works without live access, and inline all JS since artifact pages cannot load CDN scripts.

Lives in a new section of `references/output/viz-guide.md` plus a short pointer in the skill's bespoke-visualization workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)