### PR TITLE
Reject unsupported EU aggregate trade queries

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, and earnings-call transcripts — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "author": {
     "name": "Defog"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "author": {
     "name": "Defog"
   },

--- a/scripts/trade_sql.py
+++ b/scripts/trade_sql.py
@@ -183,6 +183,15 @@ def normalize_partner_name(text: str) -> str:
     return "".join(char for char in text.casefold() if char.isalnum())
 
 
+EU_AGGREGATE_QUERIES = {
+    "eu",
+    "eu27",
+    "euro",
+    "europeanunion",
+    "europeanunion27",
+}
+
+
 def same_name_codes(partners: dict[str, str], name: str) -> list[str]:
     """Return every code whose display name denotes the same partner."""
     normalized_name = normalize_partner_name(name)
@@ -238,6 +247,19 @@ def resolve_partner(source: str, text: str) -> tuple[list[str], str]:
     normalized_query = normalize_partner_name(query)
     if not normalized_query:
         fail("--partner must contain at least one letter or number")
+    # Do not let an EU/EU-27 request fall through to fuzzy matching. Some
+    # national customs maps contain names such as "Other European Territories"
+    # but do not publish a European Union aggregate, so a fragment like
+    # "euro" could otherwise produce valid-looking SQL for the wrong geography.
+    if normalized_query in EU_AGGREGATE_QUERIES:
+        eu_codes = same_name_codes(partners, "European Union")
+        if not eu_codes:
+            fail(
+                f"source '{source}' has no European Union aggregate partner — "
+                "query EU member countries separately, or use comext_sql.py "
+                "for EU-reported trade"
+            )
+        return eu_codes, partners[eu_codes[0]]
     # 2. curated alias ("united states", "south korea", "uae", ...).
     # Normalize aliases too, so "U.S." and repeated spaces work as expected.
     alias_matches = {

--- a/tests/test_trade_scripts.py
+++ b/tests/test_trade_scripts.py
@@ -382,6 +382,55 @@ class SqlGeneratorTests(unittest.TestCase):
         self.assertEqual(alias.returncode, 0, alias.stderr)
         self.assertIn("dimension_code = 'US'", alias.stdout)
 
+    def test_trade_rejects_unsupported_eu_aggregate_without_hiding_exact_codes(self):
+        common = (
+            "total",
+            "--flow",
+            "imports",
+            "--start",
+            "2025-01",
+            "--end",
+            "2025-12",
+        )
+        for partner in ("euro", "EU-27", "European Union"):
+            with self.subTest(partner=partner):
+                unsupported = run_script(
+                    "trade_sql.py",
+                    *common,
+                    "--source",
+                    "china",
+                    "--partner",
+                    partner,
+                )
+                self.assertNotEqual(unsupported.returncode, 0)
+                self.assertEqual(unsupported.stdout, "")
+                self.assertIn("no European Union aggregate partner", unsupported.stderr)
+                self.assertIn("comext_sql.py", unsupported.stderr)
+                self.assertNotIn("Traceback", unsupported.stderr)
+
+        census_eu = run_script(
+            "trade_sql.py",
+            *common,
+            "--source",
+            "census",
+            "--partner",
+            "EU-27",
+        )
+        exact_china_code = run_script(
+            "trade_sql.py",
+            *common,
+            "--source",
+            "china",
+            "--partner",
+            "399",
+        )
+        self.assertEqual(census_eu.returncode, 0, census_eu.stderr)
+        self.assertIn("dimension_code = '0003'", census_eu.stdout)
+        self.assertIn("European Union", census_eu.stdout)
+        self.assertEqual(exact_china_code.returncode, 0, exact_china_code.stderr)
+        self.assertIn("dimension_code = '399'", exact_china_code.stdout)
+        self.assertIn("Other European Territories", exact_china_code.stdout)
+
 
 class HsCodeTests(unittest.TestCase):
     def test_lookup_requires_numeric_code(self):


### PR DESCRIPTION
## What changed

- Reject EU and EU-27 partner names when a customs source does not publish an EU aggregate.
- Point users to per-member queries or Comext instead of returning a fuzzy but incorrect geography.
- Keep the US Census European Union aggregate and explicit partner codes working.

## Why

The China Customs partner list has Other European Territories but no EU-27 total. A fuzzy input such as euro could select the former and produce a valid-looking query for the wrong geography.

## Testing

- python3 -m unittest discover -s tests -v
- Plugin validation passed.