### PR TITLE
docs: document media appearance search

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Codex talk to natively over a single OAuth connection.
 │  discover   search_datasets, describe_dataset, search_series,
 │             get_data_catalog
 │  fetch      run_sql (read-only), get_series, get_market_data,
-│             search_earnings_transcripts
+│             search_earnings_transcripts, search_media_appearances
 │  publish    share_chart, share_report
 └──────────────┬──────────────┘
                │
@@ -175,7 +175,7 @@ recipes live in [`references/data/sql-guide.md`](references/data/sql-guide.md).
 
 | Region | Schemas |
 |---|---|
-| United States | SEC filings data, BLS (employment, CPI, JOLTS, OEWS), Census (trade incl. HS-level, retail, housing), BEA (GDP, income), EIA (energy), USDA ERS, BTS (transportation), earnings-call transcripts |
+| United States | SEC filings data, BLS (employment, CPI, JOLTS, OEWS), Census (trade incl. HS-level, retail, housing), BEA (GDP, income), EIA (energy), USDA ERS, BTS (transportation), earnings-call transcripts, and curated leadership media appearances |
 | China | NBS macro indicators, GACC customs (HS-level trade) |
 | India | MOSPI (CPI, WPI, IIP, GDP), RBI (banking, rates, forex), DGCI&S trade (HS-level), city traffic |
 | South Korea | KCS customs (HS-level trade) |

--- a/references/data/schemas.md
+++ b/references/data/schemas.md
@@ -18,6 +18,7 @@ file. Some schemas are admin-only and simply won't appear in your
 | `bts` | Bureau of Transportation Statistics | Transportation and freight |
 | `sec` | SEC EDGAR (~950 US-listed companies with market cap ≥ $10B) | XBRL segment/product/geography financial detail (`sec_10k`/`sec_10q`/`sec_20f`/`sec_40f`), management's forward guidance (`sec_guidance`), and company-specific operating KPIs like ARR/RevPAR/subscribers (`sec_kpi`) — call `describe_dataset` for series-ID conventions before querying |
 | *(not a SQL schema)* | Earnings-call transcripts, decomposed into a claim graph | Management's guidance/comparisons (`claims`), Q&A pressure points (`pressure_points`), disclosure profiles (`disclosure_profile`), and covered tickers/quarters (`coverage`) — searched via the `search_earnings_transcripts` tool (params: `query`, `search_target`, `company_filter` incl. comma-separated multi-ticker, `quarter_filter`, `claim_family`, `section`, `detail`, `limit`), never SQL (the underlying `transcripts` schema has a bespoke structure and no `series` table). See `references/report-patterns/earnings-intelligence.md` for the full workflow |
+| *(not a SQL schema)* | Leadership media appearances, decomposed into a claim graph | Podcasts, television interviews, and conferences searched via `search_media_appearances`, never SQL. Modes: `claims` (quote-anchored statements and YouTube deep links), `appearances` (video coverage), and `coverage` (company/channel/date aggregates). Filters: `company_filter`, `appearance_type`, `claim_family`, `date_from`, `date_to`, `detail`, and `limit`. Company/speaker attribution begins as LLM-inferred; check `attribution_confidence` and preserve `assertion_status` |
 
 ## China
 
@@ -85,7 +86,7 @@ exact series IDs rather than dimension searches.
   `india_trade` + `korea_trade` + the relevant `eu_comext_<iso2>` schemas cover
   the same flows from each country's own records when those reporters are in scope
 - Cross-country comparisons → `imf` / `worldbank`
-- Company-specific: consolidated quotes/fundamentals → `get_market_data` tool (not SQL); segment/product/geography detail, forward guidance, or operating KPIs (ARR, RevPAR, ...) → `sec` schema via `run_sql`; what management said live on a call → `search_earnings_transcripts` tool (not SQL)
+- Company-specific: consolidated quotes/fundamentals → `get_market_data` tool (not SQL); segment/product/geography detail, forward guidance, or operating KPIs (ARR, RevPAR, ...) → `sec` schema via `run_sql`; what management said live on a call → `search_earnings_transcripts`; what leadership said in podcasts, television interviews, or conferences → `search_media_appearances` (both tools, not SQL)
 
 HS trade schemas (`us_census_hs` in census, `china_customs`, `india_trade`,
 `korea_trade`) carry the same trade at multiple HS digit levels — filter to one

--- a/references/report-patterns/earnings-intelligence.md
+++ b/references/report-patterns/earnings-intelligence.md
@@ -107,14 +107,17 @@ reading if used at all.
 ## Data Source Ladder
 
 1. `search_earnings_transcripts` — spoken claims, Q&A, disclosure habits.
-2. `sec` via `run_sql` — filed XBRL segment/product/geo detail, `sec_guidance`
+2. `search_media_appearances` — off-call claims, with YouTube evidence links.
+   Treat attribution as inferred unless confirmed, check
+   `attribution_confidence`, and preserve `analyst_hypothesized`.
+3. `sec` via `run_sql` — filed XBRL segment/product/geo detail, `sec_guidance`
    formal targets, `sec_kpi` operating metrics.
-3. `get_market_data` — consolidated statements (faster than XBRL), quotes,
+4. `get_market_data` — consolidated statements (faster than XBRL), quotes,
    price history for reaction windows.
-4. Macro schemas (`bls`/`census`/`eia`/`frb`/trade/`policy`) — the
+5. Macro schemas (`bls`/`census`/`eia`/`frb`/trade/`policy`) — the
    verification layer for any macro claim.
-5. Never `run_sql` on the `transcripts` schema — it is bespoke and gated;
-   the tool is the only supported access.
+6. Never `run_sql` on the `transcripts` schema — it is bespoke and gated;
+   the transcript and media tools are the only supported access.
 
 ## Default Report Shape
 

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -5,7 +5,8 @@ description: >
   data: US indicators (BLS employment/CPI, BEA GDP, Census trade, EIA energy,
   USDA ERS, BTS transport); international data (China NBS/customs, India
   MOSPI/RBI/trade, EU Comext, Singapore, IMF, World Bank); stocks,
-  commodities/forex; and earnings-call transcripts. Use for unemployment,
+  commodities/forex; earnings-call transcripts; and leadership appearances in
+  podcasts, television interviews, and conferences. Use for unemployment,
   inflation, GDP, trade flows, energy, wages, markets, economic charts or maps,
   terminal previews, multi-section research reports, and custom HTML
   dashboards. Discover series, query SQL, compute, then return a sourced answer
@@ -22,7 +23,7 @@ allowed-tools: >
 
 You are the analyst. FactIQ provides authenticated **MCP tools** for the whole
 loop — discover the data (catalog, dataset/series search, read-only SQL, series
-lookup, market data, earnings-transcript search), then publish the result (`share_chart`,
+lookup, market data, earnings and media-appearance search), then publish the result (`share_chart`,
 `share_report`). There is no server-side agent: you decompose the question, find
 the data with the MCP tools, do the math with your own tokens, then either
 answer directly in a sentence or author the output and publish it with a tool
@@ -135,9 +136,11 @@ All FactIQ tools are MCP tools provided by the `factiq` MCP server.
 | `get_series` (`schema`, `series_id`, `from_year?`, `to_year?`) | Fetch one series — timeseries, tabular, or `COMPOUND::` ids all work. |
 | `get_market_data` (`function`, `symbol?`, `interval?`, `outputsize?`) | Quotes, daily/weekly/monthly series, fundamentals (OVERVIEW, INCOME_STATEMENT, EARNINGS), FX, commodities (WTI, BRENT, GOLD), SYMBOL_SEARCH. |
 | `search_earnings_transcripts` (`query`, `search_target?`, `company_filter?`, `quarter_filter?`, `claim_family?`, `section?`, `detail?`, `limit?`) | Full-text (lexical, not semantic) search over earnings-call transcripts — atomic, quote-anchored rows decomposed from live calls, never a raw transcript dump. All query terms must match (websearch syntax; fuzzy fallback catches typos) — retry with the company's own vocabulary (`"capital expenditure"` vs `"capex"`) before concluding silence. An empty `query` browses the newest rows: with `company_filter` that reads one call's claim spine in spoken order. `search_target`: `"claims"` (default — management's guidance/comparisons/quantified statements, with `direction`/`value`/`unit` where checkable plus `assertion_status` — never present an `analyst_hypothesized` row as management's claim), `"pressure_points"` (what analysts pressed for in Q&A and whether management confirmed/declined/deflected, incl. the specific number refused), `"disclosure_profile"` (ticker-only lookup of what a company routinely discloses vs. withholds), or `"coverage"` (which tickers/quarters exist, with claim counts — call it first when unsure a company is covered). Narrow with `company_filter` (ticker or comma-separated `"MU,NVDA"`) / `quarter_filter` (e.g. `"FY2026Q3"`) / `claim_family` (18-code vocabulary — invalid values return the list) / `section` (`"prepared_remarks"` vs `"qa"`, claims only). `detail=true` adds `structured_fields` (the per-family quantified payload) and other normalized columns. `limit` is 1–50 (default 15). For filed XBRL financials use `run_sql` on the `sec` schema; for formally issued targets use `sec_guidance` — this tool covers what was said live. Full workflow: `references/report-patterns/earnings-intelligence.md`. |
+| `search_media_appearances` (`query`, `search_target?`, `company_filter?`, `appearance_type?`, `claim_family?`, `date_from?`, `date_to?`, `detail?`, `limit?`) | Lexical full-text search over curated leadership appearances outside earnings calls — podcasts, television interviews, and conferences. `"claims"` returns atomic statements with speaker, verbatim quote, `assertion_status`, and a YouTube timestamp link; `"appearances"` lists videos and claim counts; `"coverage"` lists covered companies, channels, dates, claims, and low-confidence attribution counts. An empty query browses newest-first. Filter by primary ticker/referenced entity, appearance type, claim family, or inclusive ISO date range. Attribution starts as LLM-inferred and is admin-confirmed: check `attribution_confidence`, and never present `analyst_hypothesized` as an executive's own claim. Matching is not semantic, so retry synonyms. `detail=true` adds normalized fields and provenance state; `limit` is 1–50. |
 | `get_style_guides` (`guides`) | FactIQ's house-style guides (`"chart"`, `"report"`, `"sql"`, `"earnings"`, or `"all"`). Optional; this skill's `references/` already cover the **publishing** JSON formats — use these guides for extra house-style detail. Fetch `"earnings"` before writing anything built from `search_earnings_transcripts` (quoting discipline, spoken-vs-filed sourcing). |
 
-Every row-returning tool (`run_sql`, `get_series`, `search_earnings_transcripts`) returns **at most 50 rows**.
+Every row-returning tool (`run_sql`, `get_series`, `search_earnings_transcripts`,
+`search_media_appearances`) returns **at most 50 rows**.
 When a result comes back `"truncated": true` there is more data — your move is
 to **aggregate or compute in SQL** (a `GROUP BY date_trunc(...)`, a
 SUM/AVG/rank/ratio) and fetch that, or window a single series with


### PR DESCRIPTION
## Summary

- document the new search_media_appearances MCP tool and its claims, appearances, and coverage modes
- add the attribution-confidence and analyst_hypothesized safety rules
- include media appearances in the company-analysis source ladder and repository overview

## Verification

- uv run pytest tests/ -q: 37 passed
- git diff --check

## Dependency

This documentation accompanies defog-ai/worlddb#1087 and should merge with the backend implementation PR.