### PR TITLE
Document the IMF past-release series

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, earnings-call transcripts, a curated business-news feed, and satellite-derived data (nighttime lights, shipping and port activity, reservoir levels, crop fires and wildfires with mappable footprints, NO2/SO2/CO activity, smoke and dust aerosol, monsoon rainfall) — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "author": {
     "name": "Defog"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "author": {
     "name": "Defog"
   },

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ recipes live in [`references/data/sql-guide.md`](references/data/sql-guide.md).
 | India | MOSPI (CPI, WPI, IIP, GDP), RBI (banking, rates, forex), DGCI&S trade (HS-level), Bengaluru road traffic (2026 onward, that one city only) |
 | South Korea | KCS customs (HS-level trade) |
 | European Union | Eurostat Comext monthly trade for all 27 member-state reporters, by CN8 product and partner country |
-| Global | IMF, World Bank, Singapore SingStat, live market data (quotes, fundamentals, FX, commodities) |
+| Global | IMF (including the recent earlier releases of its forecasts, so a revision can be traced), World Bank, Singapore SingStat, live market data (quotes, fundamentals, FX, commodities) |
 
 `references/data/schemas.md` has the static overview; the `get_data_catalog` tool
 returns the live, authoritative version.

--- a/references/data/schemas.md
+++ b/references/data/schemas.md
@@ -107,11 +107,41 @@ The `uk` schema holds six datasets (filter on `dataset_code`):
 
 | Schema | Source | Coverage |
 |---|---|---|
-| `imf` | International Monetary Fund | Cross-country macro indicators |
+| `imf` | International Monetary Fund | Cross-country macro indicators, plus the earlier releases of the forecast publications (World Economic Outlook, Fiscal Monitor, the Regional Economic Outlooks, COFER) — see "IMF past releases" below |
 | `worldbank` | World Bank | Development and macro indicators by country |
 | `singstat` | Singapore Department of Statistics | Singapore national statistics |
 | `portwatch` | IMF PortWatch (satellite-AIS) | Daily shipping: transit calls + trade capacity for 28 chokepoints (Suez, Hormuz, Malacca…), port calls + import/export volume estimates for 196 countries and 2,065 ports, 2019→, refreshed weekly (data runs a few days to a week behind) |
 | `satellite` | NASA / CNES satellite-derived | Monthly nighttime lights by country + state (economic-activity proxy, Asia focus, 2019→); lake & reservoir water levels from radar altimetry (650 water bodies incl. 88 Chinese, 15 major Indian reservoirs, 1990s→, per-overpass). Water-level stations come in two grades (`grade` dimension): `operational` updates ~weekly; `research` stations are frozen scientific archives (many end 2020-22) — always check the series `end_time` before presenting a level as current, and filter to operational for live readings |
+
+## IMF past releases
+
+The IMF publishes a forecast, then replaces it in place at the next release: once
+the April 2026 World Economic Outlook is out, the October 2025 numbers are gone
+from the IMF's site. The `imf` schema keeps both, so you can show how a forecast
+moved between releases.
+
+- The plain series id is always the **newest** release. `WEO_IND.NGDPD.A` is
+  India's nominal GDP in US dollars from the current WEO.
+- An earlier release is the same id with the release appended:
+  `WEO_IND.NGDPD.A_2025OCT`, `WEO_IND.NGDPD.A_2025APR`. The suffix is the year
+  and the three-letter month of publication.
+- Earlier-release series sit in their own datasets — `dataset_code` is
+  `weo_vintages`, `fm_vintages`, `afrreo_vintages`, `apdreo_vintages`,
+  `whdreo_vintages` or `cofer_vintages` — and each one carries a `release`
+  dimension (`dimension_code` `2025OCT`, `dimension_name` "October 2025")
+  alongside the usual `country`, `indicator` and `frequency` dimensions.
+- Example of what this answers: India's projected 2030 nominal GDP was
+  6.77 trillion US dollars in the April 2025 WEO, 6.63 trillion in the October
+  2025 WEO, and 6.17 trillion in the April 2026 WEO.
+- The African and Western Hemisphere Regional Economic Outlooks (`afrreo`,
+  `whdreo`) changed their indicator codes between releases, so for those two
+  match an earlier release to the current one on the indicator's
+  `dimension_name`, not on the code. WEO, Fiscal Monitor, APDREO and COFER codes
+  are stable.
+- How far back this goes depends on the publication: the IMF only makes its
+  recent releases retrievable, so expect two or three per publication rather than
+  a long history. Query `dimension_type = 'release'` to see which ones are
+  actually there before promising a comparison.
 
 ## Picking schemas
 
@@ -124,6 +154,8 @@ The `uk` schema holds six datasets (filter on `dataset_code`):
   the same flows from each country's own records when those reporters are in scope
 - UK anything → `uk` (macro, rates, trade, environment, road traffic in one schema)
 - Cross-country comparisons → `imf` / `worldbank`
+- How an IMF forecast has been revised between releases → the `*_vintages`
+  datasets in `imf` (see "IMF past releases" above)
 - Shipping disruptions, chokepoint transits (Suez/Hormuz/Malacca), real-time
   trade activity → `portwatch` (daily grain, satellite-AIS based, refreshed
   weekly; cite IMF PortWatch)

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -275,6 +275,15 @@ local visualizations**). Local-only; never calls the API.
    `references/data/sql-guide.md`; it uses the small product lookup table and
    exact indexed series IDs.
 
+   The IMF replaces each forecast in place, but the `imf` schema also keeps the
+   recent earlier releases of the World Economic Outlook, the Fiscal Monitor,
+   the Regional Economic Outlooks and COFER. Use them for any question about how
+   a forecast has been revised. The plain series id is always the newest
+   release; an earlier one is the same id with the year and month appended
+   (`WEO_IND.NGDPD.A_2025OCT`), lives in a dataset whose code ends in
+   `_vintages`, and carries a `release` dimension. See **IMF past releases** in
+   `references/data/schemas.md`.
+
    **Domain report patterns.** If the question is broad and analytical —
    policy, trade, revenue, investment analysis, "what's driving X" — read
    `references/report-patterns/README.md` **before fetching**. It teaches the


### PR DESCRIPTION
The IMF replaces each forecast in place. Once the April 2026 World Economic
Outlook is published, the October 2025 numbers are gone from the IMF's own site.
Those earlier releases are now kept in the `imf` schema as their own series, and
nothing in the plugin docs said so — so an assistant asked how a forecast has
been revised had no way to find them.

The schemas reference now has an "IMF past releases" section explaining:

- The plain series id is always the newest release. `WEO_IND.NGDPD.A` is India's
  nominal GDP in US dollars from the current WEO.
- An earlier release is the same id with the year and three-letter month of
  publication appended: `WEO_IND.NGDPD.A_2025OCT`.
- Earlier-release series sit in their own datasets, whose `dataset_code` ends in
  `_vintages` — `weo_vintages`, `fm_vintages`, `afrreo_vintages`,
  `apdreo_vintages`, `whdreo_vintages`, `cofer_vintages`.
- Each one carries a `release` dimension (code `2025OCT`, name "October 2025")
  alongside the usual country, indicator and frequency dimensions, so releases
  can be lined up without slicing strings out of the id.
- Only the IMF's recent releases can be retrieved, so expect two or three per
  publication rather than a long history. Check which ones are present before
  promising a comparison.
- The African and Western Hemisphere Regional Economic Outlooks changed their
  indicator codes between releases, so for those two an earlier release must be
  matched to the current one on the indicator's name, not its code.

The schema table row for `imf` and the "Picking schemas" list both point at the
new section. Plugin version goes to 0.26.2.