### PR TITLE
Bump FactIQ plugin versions after removing publishing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "factiq",
       "source": "./",
-      "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, earnings-call transcripts, executive media appearances, and a curated business-news feed — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations."
+      "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, earnings-call transcripts, executive media appearances, and a curated business-news feed — return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
-  "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, earnings-call transcripts, executive media appearances, a curated business-news feed, and satellite-derived data (nighttime lights, shipping and port activity, reservoir levels, crop fires and wildfires with mappable footprints, NO2/SO2/CO activity, smoke and dust aerosol, monsoon rainfall) — publish shareable charts and reports, render terminal previews, or build bespoke local HTML visualizations.",
-  "version": "0.26.4",
+  "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, earnings-call transcripts, executive media appearances, a curated business-news feed, and satellite-derived data (nighttime lights, shipping and port activity, reservoir levels, crop fires and wildfires with mappable footprints, NO2/SO2/CO activity, smoke and dust aerosol, monsoon rainfall) — return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
+  "version": "0.26.5",
   "author": {
     "name": "Defog"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
-  "description": "Answer economic and financial data questions with real data from FactIQ — official data, markets, earnings calls, and executive media appearances — then publish charts, reports, terminal previews, or bespoke HTML visualizations.",
-  "version": "0.19.3",
+  "description": "Answer economic and financial data questions with real FactIQ data — official data, markets, earnings calls, and executive media appearances — then return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
+  "version": "0.19.4",
   "author": {
     "name": "Defog"
   },
@@ -19,7 +19,7 @@
   "interface": {
     "displayName": "FactIQ",
     "shortDescription": "Economic and financial data analysis",
-    "longDescription": "Use FactIQ to answer economic and financial data questions with catalog search, read-only SQL, market data, earnings-transcript search, deterministic executive-media search, shareable charts, terminal previews, reports, and bespoke local HTML visualizations.",
+    "longDescription": "Use FactIQ for catalog search, read-only SQL, market data, earnings-transcript search, deterministic executive-media search, satellite signals, terminal previews, report JSON, and bespoke local HTML visualizations.",
     "developerName": "Defog",
     "category": "Finance",
     "capabilities": [

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -1,25 +1,17 @@
 ---
 name: factiq
 description: >
-  Answer economic and financial data questions with real FactIQ (worlddb)
-  data: US indicators (BLS employment/CPI, BEA GDP, Census trade, EIA energy,
-  USDA ERS, BTS transport); international data (China NBS/customs, India
-  MOSPI/RBI/trade, EU Comext, Singapore, IMF, World Bank); stocks,
-  commodities/forex; earnings-call transcripts; executive media appearances
-  from podcasts, TV interviews, and conferences; a curated business-news feed;
-  and satellite-derived data: nighttime lights by country and state,
-  lake and reservoir water levels, daily shipping and port activity
-  (chokepoint transits, port calls, seaborne trade estimates), plus on-demand
-  signals (fire detections/crop burning with mappable footprints, NO2/SO2/CO
-  industrial and combustion activity, smoke and dust aerosol, crop-condition
-  NDVI, monsoon rainfall, heatwaves, soil moisture — by country, state, or
-  bounding box). Use for unemployment, inflation, GDP, trade flows, energy, wages,
-  markets, earnings and executive-media intelligence, recent news context,
-  stubble burning, wildfires, air quality,
-  monsoon or drought conditions, nighttime lights, reservoir levels, shipping
-  or chokepoint traffic, economic charts or maps, terminal previews,
-  multi-section research reports, and custom HTML dashboards. Discover series, query SQL, compute, then return a sourced answer
-  or render the requested output. For bilateral trade, use the bundled SQL generators instead of hand-writing schema-specific queries.
+  Answer economic and financial data questions with FactIQ data: US and
+  international indicators, trade, markets, earnings calls, executive media,
+  business news, and satellite signals. Satellite coverage includes rainfall,
+  fires, air quality, NDVI, heat, soil moisture, nighttime lights, reservoir
+  levels, shipping, ports, and chokepoints by country, state, or bounding box.
+  Use for unemployment, inflation, GDP, wages, energy, trade flows, stocks,
+  commodities, forex, earnings intelligence, drought and monsoon conditions,
+  wildfires, economic charts and maps, terminal previews, research reports,
+  and custom HTML dashboards. Discover series, query read-only SQL, compute,
+  then return a sourced answer or local output. Use the bundled SQL generators
+  for bilateral trade.
 allowed-tools: >
   mcp__plugin_factiq_factiq__*,
   mcp__factiq__*,

--- a/tests/test_retired_publishing_tools.py
+++ b/tests/test_retired_publishing_tools.py
@@ -6,7 +6,12 @@ RETIRED_NAMES = {"share_chart", "share_report", "list_my_artifacts"}
 
 
 def test_public_plugin_does_not_reference_retired_publishing_tools():
-    paths = [ROOT / "README.md"]
+    paths = [
+        ROOT / "README.md",
+        ROOT / ".codex-plugin/plugin.json",
+        ROOT / ".claude-plugin/plugin.json",
+        ROOT / ".claude-plugin/marketplace.json",
+    ]
     for folder in ("commands", "skills", "references", "scripts"):
         paths.extend((ROOT / folder).rglob("*.md"))
         paths.extend((ROOT / folder).rglob("*.py"))


### PR DESCRIPTION
The publishing workflow changed in plugin PR #84, but that PR did not update the plugin versions. The plugin manifests also retained descriptions for the removed publishing tools.

This follow-up sets the Codex plugin to 0.19.4 and the Claude plugin to 0.26.5. It updates the manifest descriptions, expands the retirement regression test to cover the manifests, and shortens the skill trigger description so it passes the 1,024-character validator limit.

Before

Representative input: read installed FactIQ plugin metadata.

```json
{"codex_version":"0.19.3","claude_version":"0.26.4","output":"publish shareable charts and reports"}
```

After

Representative input: read installed FactIQ plugin metadata.

```json
{"codex_version":"0.19.4","claude_version":"0.26.5","output":"return sourced answers, terminal previews, report JSON, or bespoke local HTML"}
```

Validation:
- Plugin manifest validator passed.
- FactIQ skill validator passed.
- `python3 -m pytest tests` — 49 passed.