### PR TITLE
Document the new fire-data capabilities

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, earnings-call transcripts, executive media appearances, a curated business-news feed, and satellite-derived data (nighttime lights, shipping and port activity, reservoir levels, crop fires and wildfires with mappable footprints, NO2/SO2/CO activity, smoke and dust aerosol, monsoon rainfall) — return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
-  "version": "0.26.6",
+  "version": "0.27.0",
   "author": {
     "name": "Defog"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
-  "description": "Answer economic and financial data questions with real FactIQ data — official data, markets, earnings calls, and executive media appearances — then return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
-  "version": "0.19.5",
+  "description": "Answer economic and financial data questions with real FactIQ data — official data, markets, earnings calls, executive media appearances, and satellite-derived signals including crop fires and wildfires — then return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
+  "version": "0.20.0",
   "author": {
     "name": "Defog"
   },

--- a/references/data/satellite.md
+++ b/references/data/satellite.md
@@ -11,20 +11,26 @@ Read this before the first `get_geo_data` call in a session.
 ## The tool
 
 ```
-get_geo_data(dataset, region, start_date, end_date, aggregation="monthly")
+get_geo_data(dataset, region, start_date, end_date, aggregation="monthly",
+             resolution=None, include_flares=False)
 ```
 
 Returns `{columns, results, units, region, organization, attribution,
 caveats, notes?}` — a small time series, at most 50 rows (the spatial modes
-below return up to 500). Results are cached server-side, so repeating a call
-is cheap; the first call to an external provider can take 5–30 s (rainfall
-occasionally longer).
+below return up to 500, and `fires_viirs` time series up to 200). Results are
+cached server-side, so repeating a call is cheap; the first call to an external
+provider can take 5–30 s (rainfall occasionally longer). `fires_viirs` is the
+exception: FactIQ holds every detection since 2012 in its own database, so
+those calls answer in well under a second and no provider quota applies.
+
+`resolution` and `include_flares` apply to `fires_viirs` only — see the fires
+sections below. Passing either for another dataset is an error.
 
 ## Datasets
 
 | dataset | measures | economic reading | history | lag |
 |---|---|---|---|---|
-| `fires_viirs` | Active-fire detections + fire radiative power (NASA FIRMS, VIIRS 375 m) | Crop-residue burning (Punjab/Haryana Oct–Nov, Indonesian burning season), deforestation fires, wildfires, flaring | 2012→ | ~3 h |
+| `fires_viirs` | Active-fire detections + fire radiative power (NASA FIRMS, VIIRS 375 m) | Crop-residue burning (Punjab/Haryana Oct–Nov, Indonesian burning season), deforestation fires, wildfires, flaring | 2012→ | 1 day (yesterday is the newest complete day) |
 | `no2_tropomi` | Tropospheric NO₂ column, quality-filtered area mean (Sentinel-5P) | Industrial + power + traffic activity; recessions and lockdowns show up in weeks, not quarters | 2018→ | ~3 days |
 | `so2_tropomi` | SO₂ column, area mean (Sentinel-5P) | Coal power generation, smelting, refining; also volcanic eruptions. Noisy away from strong sources — read it as a trend near known source regions, never as absolute background levels (single values can even be negative) | 2018→ | ~3 days |
 | `co_tropomi` | CO column, area mean (Sentinel-5P) | Biomass and crop-residue burning, wildfire smoke, industrial combustion — pairs with `fires_viirs` (detections say where, CO says how much is going into the air). CO lingers for weeks and drifts across borders; compare the same season across years | 2018→ | ~3 days |
@@ -47,20 +53,40 @@ occasionally longer).
 The response's `region.resolved` echoes what was actually used — repeat it in
 your narrative so the reader knows the exact geography.
 
-## Windows and the 50-row budget
+## Windows and the row budget
 
-At most 50 intervals per call (~4 years monthly, ~7 weeks daily). Patterns:
+At most 50 intervals per call (~4 years monthly, ~7 weeks daily) — except
+`fires_viirs`, which allows 200 (~16 years monthly, ~6 months daily). Patterns:
 
 - **Seasonal YoY** (the common ask — "Punjab stubble burning this year vs
-  last 5"): one call per season, e.g. `2021-10-01→2021-11-30`,
-  `2022-10-01→2022-11-30`, … in parallel. Don't fetch whole years to compare
-  two months.
+  last 5"): for `fires_viirs` use `aggregation="seasons"` — **one call** gives
+  you every year (see below). For the other datasets, one call per season, e.g.
+  `2021-10-01→2021-11-30`, `2022-10-01→2022-11-30`, … in parallel. Don't fetch
+  whole years to compare two months.
 - **Long trends**: split at the 50-month boundary (e.g. 2018–2021, 2022–2025)
-  and stitch.
-- **`fires_viirs` is additionally capped at 3 years per call** (the provider
-  serves 5-day chunks); seasonal calls sidestep this entirely.
+  and stitch. `fires_viirs` needs no splitting — the whole 2012→ history fits
+  in one monthly call.
 - Daily grain is for event windows (a flood week, a heatwave fortnight), not
   long ranges.
+
+## Comparing a season across every year — `aggregation="seasons"` (fires_viirs only)
+
+Ask for one calendar window and get one row per year since 2012:
+`year`, `fire_detections`, `total_frp_mw`. The window's month and day are
+repeated in each year, so it answers "is this burning season worse than the
+ones before it" in a single call.
+
+```
+get_geo_data("fires_viirs", "India/Punjab", "2025-10-15", "2025-11-15",
+             aggregation="seasons")
+```
+
+- The year you pass doesn't matter — the same list of seasons comes back
+  either way. Only the month and day are used.
+- A window crossing new year (20 Dec → 10 Feb) keeps its length and is
+  labelled by the year it starts in, so a season isn't split in two.
+- Seasons whose start date hasn't arrived yet are left out.
+- Window capped at 366 days: it has to be a season, not several years.
 
 ## Mapping where the signal is — `aggregation="grid"`
 
@@ -79,29 +105,64 @@ requested window.
   `no2_mol_m2`, `so2_mol_m2`, `co_mol_m2`, `uv_aerosol_index`) plus
   `valid_obs_share`. The same cloud/quality rule as the time series applies
   per cell — a cell with a low share rests on few clear-sky views.
-- Window is capped at **92 days**: one season or one event per call, not a
-  multi-year history.
-- Cell size is picked automatically from the region's size — roughly 1 km
-  cells for a single fire complex, coarser for a whole large country, and
-  never finer than the dataset's native resolution. At most 500 cells come
-  back.
+- Window is capped at **92 days** — one season or one event per call — except
+  `fires_viirs`, which allows **366 days**.
+- Cell size: for the Sentinel datasets it is picked automatically from the
+  region's size and never goes finer than the dataset's native resolution.
+  For `fires_viirs` you can pick it yourself with `resolution` (see below).
+  At most 500 cells come back either way.
 - Use it to feed a map (see the Maps section of
   `references/output/chart-spec.md`): a bubble map of a fire event or burning
   season, NO₂ across an industrial belt, NDVI across a growing region. Use
   `monthly`/`daily` for trends and comparisons.
 
+### Choosing the fire map's cell size — `resolution` (fires_viirs only)
+
+`resolution` is the cell size in degrees, one of `0.005, 0.01, 0.02, 0.05,
+0.1, 0.2, 0.5, 1, 2, 5`. Anything else is an error listing these.
+
+Leave it out and the finest cell that still maps the whole region in one call
+is chosen, never finer than 0.1° — 0.1° for a small area, 0.2° for a state like
+Punjab, coarser for a country. Set it when the automatic choice is wrong for
+the map you want:
+
+```
+# Where in Punjab did it burn, street-block detail
+get_geo_data("fires_viirs", "bbox:74,29.5,77,32", "2025-11-01", "2025-11-07",
+             aggregation="grid", resolution=0.01)
+```
+
+Cells at 0.1° or coarser are read from pre-computed daily totals; finer cells
+are computed from the individual detections. Either way you get the 500
+busiest cells, and a `notes` entry says if less busy ones were dropped.
+
 ## Exact fire locations — `aggregation="points"` (fires_viirs only)
 
 `fires_viirs` also accepts `"points"`: the individual detections, one row per
-detection — `latitude`, `longitude`, `date`, `frp_mw` — exact satellite
-coordinates, no binning.
+detection — `latitude`, `longitude`, `date`, `frp_mw`, `confidence` (`l` low,
+`n` nominal, `h` high) — exact satellite coordinates, no binning.
 
 - Works only when the window has **at most 500 detections**. Above that the
   call returns an error naming the actual count — narrow the region or dates,
   or switch to `"grid"`.
-- Same 92-day window cap as `"grid"`.
+- Window capped at 366 days, same as `"grid"` for fires.
 - `"grid"` always bins, even when the window is small — ask for `"points"`
   explicitly when the map needs exact locations.
+
+## Gas flares and other non-fires — `include_flares` (fires_viirs only)
+
+NASA labels each detection: vegetation fire, volcano, gas flare or other
+permanent industrial heat source, or offshore. **Flares and the rest are left
+out by default**, in every fires mode, because a gas field burns every day of
+the year and would otherwise read as a permanent wildfire.
+
+Set `include_flares=True` to count every detection NASA publishes — the right
+call when the question *is* about flaring (Basra, the Permian, the Niger
+Delta) or volcanic activity. Say which you used; the two give very different
+counts over an oil-producing region.
+
+Detections from the last few weeks have no label yet. They are counted as
+vegetation fires either way, so the newest data is never silently missing.
 
 ## Reading the results honestly
 
@@ -119,7 +180,12 @@ coordinates, no binning.
   years is the signal, not the Nov→Feb climb.
 - `fires_viirs` counts overpass detections, not fires put out — cloud cover
   suppresses counts; compare like-for-like seasons, and prefer `total_frp_mw`
-  when arguing intensity rather than frequency.
+  when arguing intensity rather than frequency. One fire makes many
+  detections across many overpasses, and a fire that starts and dies between
+  overpasses makes none.
+- `fires_viirs` `notes` says when part of the requested window is not loaded
+  yet. Those days count as zero, not as days with no fires — read the note
+  before calling a recent stretch quiet.
 - `precip_chirps` recent days are preliminary and revised in the final
   monthly product (~3rd week of the following month).
 - `precip_chirps` ends at 50°N and 50°S. Use `precip_imerg` outside
@@ -144,6 +210,11 @@ Sentinel-5P data…") is a licence requirement, not a courtesy.
 
 - Not a raster or tile service: results are regional aggregates (plus the
   grid snapshots and fire detection points above) — never imagery.
+- Not the only way to reach the fire data. Every detection since 2012 is also
+  queryable with `run_sql` as the `nasa_fires` schema, for shapes this tool
+  doesn't cover (ranking countries, joining fires to something else, night
+  passes versus day passes). See `references/data/schemas.md`. Use the tool
+  first — it answers the common questions with no SQL.
 - Several satellite signals live in the WAREHOUSE instead of this tool, as
   the `satellite` SQL schema: monthly **nighttime lights** by country/state
   (precomputed — no hosted aggregation API exists) and **lake/reservoir water

--- a/references/data/schemas.md
+++ b/references/data/schemas.md
@@ -112,6 +112,7 @@ The `uk` schema holds six datasets (filter on `dataset_code`):
 | `worldbank` | World Bank | Development and macro indicators by country |
 | `singstat` | Singapore Department of Statistics | Singapore national statistics |
 | `portwatch` | IMF PortWatch (satellite-AIS) | Daily shipping: transit calls + trade capacity for 28 chokepoints (Suez, Hormuz, Malacca…), port calls + import/export volume estimates for 196 countries and 2,065 ports, 2019→, refreshed weekly (data runs a few days to a week behind) |
+| `nasa_fires` | NASA FIRMS (VIIRS 375 m) | Every active-fire detection worldwide since 2012-01-20, one row per satellite pixel, plus pre-computed daily totals per country, per state, and per 0.1° cell. Refreshed daily. **Shaped unlike every other schema — read "The nasa_fires schema" below before writing SQL.** Most fire questions need no SQL at all: use `get_geo_data` (see `references/data/satellite.md`) |
 | `satellite` | NASA / CNES satellite-derived | Monthly nighttime lights by country + state (economic-activity proxy, Asia focus, 2019→); lake & reservoir water levels from radar altimetry (650 water bodies incl. 88 Chinese, 15 major Indian reservoirs, 1990s→, per-overpass). Water-level stations come in two grades (`grade` dimension): `operational` updates ~weekly; `research` stations are frozen scientific archives (many end 2020-22) — always check the series `end_time` before presenting a level as current, and filter to operational for live readings |
 
 ## IMF past releases
@@ -144,6 +145,47 @@ moved between releases.
   a long history. Query `dimension_type = 'release'` to see which ones are
   actually there before promising a comparison.
 
+## The nasa_fires schema
+
+A fire detection is one satellite pixel that was burning at one moment. It
+belongs to no series, so **this schema has no `series` table and no
+`data_points` table** — the usual discovery method does not apply. Five tables:
+
+- **`detections`** — one row per detection since 2012-01-20: `acq_ts` (UTC
+  timestamp of the overpass), `latitude`, `longitude`, `frp` (fire radiative
+  power in megawatts — the heat), `bright_ti4`, `bright_ti5`, `country_id`,
+  `admin1_id`, `type`, `confidence` (`l`/`n`/`h`), `daynight` (`D`/`N`),
+  `quality` (`S` final, `N` provisional).
+- **`region_daily`** — daily `detections` and `frp_sum` per country and state.
+  `admin1_id = 0` is the country total, stored as a row **alongside** the state
+  rows — so filter to `admin1_id = 0` for countries or `admin1_id > 0` for
+  states. Summing both double-counts.
+- **`grid_daily`** — the same daily totals per 0.1° cell. `cell_lat` and
+  `cell_lon` are `floor(degrees * 10)`, so cell 302 covers 30.2 to 30.3.
+- **`countries`** and **`admin1`** — id-to-name lookups, joined on
+  `country_id` / `admin1_id`.
+
+**Read `type` before counting anything**: `0` vegetation fire, `1` volcano,
+`2` gas flare or other industrial heat, `3` offshore, `-1` NASA has not
+classified it yet — which is every detection from the last few weeks.
+`type IN (0, -1)` is wildfire and crop burning; `type = 2` is flaring. A bare
+`type = 0` silently drops the newest data.
+
+A detection is not a fire: one fire produces many detections across many
+overpasses, and a fire that burns out between overpasses produces none. Count
+rows for extent, sum `frp` for intensity.
+
+`run_sql` accepts a `page` argument **on this schema only** — 50 rows at a
+time, with `has_more` telling you whether to ask for the next one. Give the
+query an `ORDER BY` or the pages won't line up. Totals still belong in SQL;
+never page through thousands of detections to add them up yourself.
+
+Prefer `get_geo_data` (`references/data/satellite.md`) — it answers monthly or
+daily counts for a region, one window compared across every year since 2012, a
+map grid, and the raw points in a small box, with no SQL at all. Come here for
+the shapes it doesn't cover: ranking many countries at once, joining fires to
+another dataset, or splitting day passes from night passes.
+
 ## Picking schemas
 
 - US labor/inflation → `bls` (plus `oews` for occupation-level wages)
@@ -164,6 +206,9 @@ moved between releases.
   irrigation, drought) → `satellite` schema; for on-demand fires/NO2/SO2/CO/
   aerosol/rainfall/NDVI over arbitrary regions → the `get_geo_data` tool
   instead (see `references/data/satellite.md`)
+- Crop burning, wildfires, gas flaring → `get_geo_data` first; drop to the
+  `nasa_fires` schema only for shapes the tool doesn't cover (see "The
+  nasa_fires schema" above)
 - Company-specific: consolidated quotes/fundamentals → `get_market_data` tool (not SQL); segment/product/geography detail, forward guidance, or operating KPIs (ARR, RevPAR, ...) → `sec` schema via `run_sql`; what management said live on a call → `search_earnings_transcripts` tool (not SQL)
 - What executives said in podcasts, television interviews, and conferences
   outside earnings calls → `search_media_appearances` (not SQL); follow `references/report-patterns/media-intelligence.md`

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -114,10 +114,10 @@ All FactIQ tools are MCP tools provided by the `factiq` MCP server.
 | `search_datasets` (`query`, `schemas?`, `limit?`) | Keyword (not semantic) ranking of datasets across all schemas. **The first discovery step** — find the right `schema` + `dataset_code`. |
 | `describe_dataset` (`schema`, `dataset_code`) | Full metadata for one dataset: topic, methodology, release dates, base-change notice, dimensions, example series. Call after `search_datasets`. |
 | `search_series` (`schema`, `terms`, `limit?`, `include_compound?`) | Series-level title-substring search within one schema (`terms` is a list — prefer short stems). Includes `COMPOUND::` series. |
-| `run_sql` (`schema`, `sql`, `question?`, `explore?`, `auto_retry?`) | Read-only SELECT against one schema. The power tool for joins, pivots, aggregation. |
+| `run_sql` (`schema`, `sql`, `question?`, `explore?`, `auto_retry?`, `page?`) | Read-only SELECT against one schema. The power tool for joins, pivots, aggregation. `page` works on the `nasa_fires` schema only, where individual rows are the answer; everywhere else, aggregate. |
 | `get_series` (`schema`, `series_id`, `from_year?`, `to_year?`) | Fetch one series — timeseries, tabular, or `COMPOUND::` ids all work. |
 | `get_market_data` (`function`, `symbol?`, `interval?`, `outputsize?`) | Quotes, daily/weekly/monthly series, fundamentals (OVERVIEW, INCOME_STATEMENT, EARNINGS), FX, commodities (WTI, BRENT, GOLD), SYMBOL_SEARCH. |
-| `get_geo_data` (`dataset`, `region`, `start_date`, `end_date`, `aggregation?`) | Satellite-derived signals, fetched live rather than stored as series: `fires_viirs` (crop burning/wildfires, ~3h lag; `aggregation="grid"` maps the fire's footprint, `aggregation="points"` returns exact detection coordinates when the window has ≤500), `no2_tropomi` / `so2_tropomi` / `co_tropomi` (industrial, coal/smelting, and combustion activity), `aerosol_index_tropomi` (smoke/dust/haze), `ndvi_s2` (crop condition) — these five also accept `aggregation="grid"` for a cell-by-cell spatial snapshot — `precip_chirps` (0.05° gauge-calibrated rainfall within 50S-50N), `precip_imerg` (0.1° global rainfall), `temperature_power`, `soil_moisture_power` — aggregated over a country, state (`"India/Punjab"`), or bbox. **Read `references/data/satellite.md` before first use** — it covers windows (max 50 intervals; grid/points max 92 days), the `valid_obs_share` rule, and attribution. |
+| `get_geo_data` (`dataset`, `region`, `start_date`, `end_date`, `aggregation?`, `resolution?`, `include_flares?`) | Satellite-derived signals: `fires_viirs` (crop burning/wildfires; every detection since 2012 is held in FactIQ's own database, so calls answer in under a second — `aggregation="seasons"` compares the same calendar window in every year since 2012 in one call, `"grid"` maps the footprint at a cell size you pick with `resolution`, `"points"` returns exact detection coordinates), `no2_tropomi` / `so2_tropomi` / `co_tropomi` (industrial, coal/smelting, and combustion activity), `aerosol_index_tropomi` (smoke/dust/haze), `ndvi_s2` (crop condition) — these five also accept `aggregation="grid"` for a cell-by-cell spatial snapshot — `precip_chirps` (0.05° gauge-calibrated rainfall within 50S-50N), `precip_imerg` (0.1° global rainfall), `temperature_power`, `soil_moisture_power` — aggregated over a country, state (`"India/Punjab"`), or bbox. `resolution` and `include_flares` apply to `fires_viirs` only; gas flares and other permanent industrial heat are excluded unless you ask for them. **Read `references/data/satellite.md` before first use** — it covers windows (50 intervals, 200 for fires; grid/points 92 days, 366 for fires), the `valid_obs_share` rule, and attribution. For fire questions this tool does not cover, query the `nasa_fires` SQL schema (`references/data/schemas.md`). |
 | `search_earnings_transcripts` (`query`, `search_target?`, `company_filter?`, `quarter_filter?`, `claim_family?`, `section?`, `detail?`, `limit?`) | Lexical (not semantic) retrieval over atomic, quote-anchored earnings-call rows — never a raw transcript dump. For a non-empty `query`, strict websearch matches rank above an automatically broadened loose partial-match OR-of-tokens tier, so lower-ranked rows may match only some terms; trigram fallback runs only when full-text search returns no rows. Inspect every row for support and retry concise company-native vocabulary (`"capital expenditure"`, `"capex"`, segment names) before concluding lexical silence. For one-call notes, first use `search_target="coverage"`, choose its exact returned `latest_period`, then browse `claims` with `query=""`, that ticker + `quarter_filter`, `detail=true`, and a deliberate limit; fetch `pressure_points` with the same ticker and quarter. The browse is capped, not a promise of a complete call. Quote only `verbatim_quote`; `canonical_statement` is normalized, and neither `analyst_hypothesized` nor `mgmt_declined_to_confirm` is a management assertion. For filed XBRL actuals use `run_sql` on `sec`; for formal targets use `sec_guidance`. Full target/filter reference and workflows: `references/report-patterns/earnings-intelligence.md`. |
 | `search_media_appearances` (`query`, `search_target?`, `company_filter?`, `person?`, `sort?`, `appearance_type?`, `claim_family?`, `date_from?`, `date_to?`, `detail?`, `limit?`) | Deterministic, lexical retrieval over precomputed public-safe paraphrases of what executives said outside earnings calls; **no serving-time model** interprets or expands the query. Strict lexical FTS runs first, loose any-term FTS only when strict finds no candidates, and trigram fallback only when both FTS stages are empty. Prefer concise topical language and retry company-native synonyms before concluding silence. Canonical targets are `search` (default claims + passages blend), `claims`, `passages`, `pressure_points`, `appearances`, and `coverage`; compatibility aliases `all`, `videos`, and `companies` map respectively to `search`, `appearances`, and `coverage` and are not recommended for new calls. `sort="relevance"` ranks lexical score before publication date; `sort="newest"` ranks publication date before lexical score. `company_filter` accepts comma-separated primary tickers; `person` is a case-insensitive speaker-name substring; `appearance_type`, `claim_family`, inclusive `date_from`/`date_to`, `detail`, and `limit` provide further narrowing. Dates are the video's publication/upload date, not necessarily its recording/event date. `claim_family` makes blended search claims-only, is invalid with `passages`, and requires matching claims for catalog targets. Structured finding rows expose `result_kind`, `canonical_paraphrase`, speaker/topic/video metadata, relevance, and a timestamped YouTube URL; `appearances` returns video-level metadata, attribution, matching-claim count, URL, and relevance; `coverage` returns company-level structured corpus counts and date/channel inventory. `detail=true` adds normalized claim/attribution fields to finding rows, but never raw transcript text or evidence spans; claim-only fields remain null on passages and detail does not change catalog rows. Never put `canonical_paraphrase` in quotation marks or claim it is verbatim; follow the timestamped source when exact wording or tone matters. Empty-query behavior and the complete workflow are in `references/report-patterns/media-intelligence.md`. |
 | `search_news` (`query?`, `tickers?`, `topic?`, `sources?`, `start_date?`, `end_date?`, `sort?`, `limit?`) | Search FactIQ's curated business-news feed — public RSS headlines and summaries from Bloomberg, the Financial Times, and the Wall Street Journal, plus India-macro (Zerodha Daily Brief, ET HealthWorld) and global-health sources (WHO, ECDC, CDC, STAT News, KFF), aggregated and processed by FactIQ so each article carries the listed companies it names (`{symbol, exchange, country}`) and an `analysis` block: searchable keywords, a geography, and an `angle` — one sentence on why the story matters to an investor. Company stories get analysis too, not just macro ones; only content with no business read at all (sports, lifestyle, celebrity) comes back with `analysis: null`. Pivot from a story into data: company stories → `get_market_data` / `search_earnings_transcripts` / `run_sql` on `sec`; macro stories → `search_series` / `run_sql`. Results are headline + short publisher summary + link out, never full articles. `query` is lexical full-text over headline+summary — start with short concrete stems (`"obesity drug"`, `"rate cut"`); if a multi-word query matches nothing in full, the tool automatically retries matching ANY of the words with rare words ranked first, flagged as `meta.query_mode: "any_term"`, so one query attempt is usually enough. `tickers` matches share classes and cross-listings automatically (GOOG also finds GOOGL-tagged articles, TSM its Taiwan listing) — pass whichever symbol you know; most macro stories name no listed company, so zero ticker matches is a normal answer. `topic` is one of markets / economics / companies / technology / politics / world / energy / health / india / opinion — combined with a `query` it is a ranking preference (matching sections rank first, but strong matches from other sections still return, since stories often run outside their obvious feed); without a query it filters to the topic's feeds. `sort` is `"latest"` (default) or `"relevance"` (needs a query); `limit` 1–50 (default 20). Coverage is recent news (most feeds start late 2025), and the feed is continuously being expanded and improved — treat it as a current-events lens, not an archive. |
@@ -294,7 +294,10 @@ local visualizations**). Local-only; never calls the API.
    chokepoints, ports, country trade estimates) and `satellite` (nighttime
    lights by state, lake/reservoir water levels) — see
    `references/data/schemas.md` for routing and
-   `references/data/satellite.md` for the on-demand geo tool.
+   `references/data/satellite.md` for the on-demand geo tool. Fire detections
+   live in a third schema, `nasa_fires`, which holds raw detections rather than
+   series and is shaped unlike the others — read its section in
+   `references/data/schemas.md` before writing SQL against it.
 
    Eurostat Comext is the exception: country schemas contain millions of
    series, so do not explore their `series` or `dimensions` tables by text or
@@ -355,11 +358,13 @@ local visualizations**). Local-only; never calls the API.
    monsoon rainfall, heatwaves, or agricultural drought — where satellite
    observation runs ahead of official statistics — use `get_geo_data`. Read
    `references/data/satellite.md` first: it covers the ten datasets, region
-   syntax, the 50-interval window budget (seasonal comparisons = one call per
-   season), the `grid` mode for mapping where a signal sits (fires, NDVI,
-   air quality), the fires-only `points` mode for exact detection
-   coordinates, cloud-cover caveats, and required attribution. Satellite data complements
-   warehouse series; prefer curated series where both exist.
+   syntax, the window budget (50 intervals, 200 for fires), the `grid` mode for
+   mapping where a signal sits (fires, NDVI, air quality), the fires-only
+   `points`, `seasons`, `resolution`, and `include_flares` controls, cloud-cover
+   caveats, and required attribution. Fires are the one dataset FactIQ stores
+   itself — every detection since 2012 — so a fourteen-year seasonal comparison
+   is one call. Satellite data complements warehouse series; prefer curated
+   series where both exist.
 7. **Answer, render, or build.** Direct-answer mode: reply with one sentence
    that states the number, period, and source. Quick-chart mode: build a
    ChartSpec from wide-format data (see `references/output/chart-spec.md`), save
@@ -626,6 +631,12 @@ rows**, and there is no "give me everything" option — by design. The cap keeps
 results context-sized, so you do **not** stage data to disk to protect your
 context; you take the tool result directly.
 
+There is one exception. In the `nasa_fires` schema a row is a single satellite
+fire detection, which belongs to no series and carries no value to average, so
+the rows themselves can be the answer. There `run_sql` accepts `page` and walks
+the result 50 rows at a time. Give the query an `ORDER BY`, or the pages will
+not line up. No other schema accepts `page`.
+
 When a result comes back `"truncated": true`, there is more data and your move
 is to **aggregate or compute it in SQL**, not to try to fetch the raw rows:
 
@@ -677,7 +688,8 @@ payload from the transcript so you never retype the rows.
   literals, national vs sub-national, pivots, tabular data).
 - `satellite.md` — the `get_geo_data` satellite tool: datasets and their
   economic reading, region syntax and coverage, window budgeting, the
-  spatial `grid` and fires-only `points` modes, cloud/quality caveats,
+  spatial `grid` mode, the fires-only `points` and `seasons` modes and the
+  `resolution` / `include_flares` controls, cloud/quality caveats,
   attribution requirements.
 
 **`references/output/`** — local output formats:


### PR DESCRIPTION
## What changed on the server

The fire dataset behind `get_geo_data` used to call NASA for every request. It
now answers from FactIQ's own store of every VIIRS detection since 2012. That
made four new things possible, and none of them were in the docs:

1. `aggregation="seasons"` — one calendar window, one row per year, since 2012.
2. `resolution` — the caller picks the map's cell size.
3. `include_flares` — gas flares and other permanent industrial heat are left
   out by default; ask for them when the question is about flaring.
4. The detections are also queryable as the `nasa_fires` SQL schema, and
   `run_sql` accepts a `page` argument there.

Some old limits are gone too. The per-call budget for fires rose from 50
intervals to 200, the grid and points windows from 92 days to 366, and the
"3 years per call" cap disappeared entirely.

## Before and after

**Question the agent gets: "how has stubble burning in Punjab during 15 October
to 15 November changed since 2012?"**

Before, the docs told the agent to make one call per season:

> **Seasonal YoY** (the common ask — "Punjab stubble burning this year vs
> last 5"): one call per season, e.g. `2021-10-01→2021-11-30`,
> `2022-10-01→2022-11-30`, … in parallel. Don't fetch whole years to compare
> two months.
>
> **`fires_viirs` is additionally capped at 3 years per call** (the provider
> serves 5-day chunks); seasonal calls sidestep this entirely.

Fourteen calls for fourteen years.

After, the docs point at a mode that did not exist before:

> **Seasonal YoY** (the common ask — "Punjab stubble burning this year vs
> last 5"): for `fires_viirs` use `aggregation="seasons"` — **one call** gives
> you every year (see below). For the other datasets, one call per season …
>
> ## Comparing a season across every year — `aggregation="seasons"` (fires_viirs only)
>
> ```
> get_geo_data("fires_viirs", "India/Punjab", "2025-10-15", "2025-11-15",
>              aggregation="seasons")
> ```
>
> - The year you pass doesn't matter — the same list of seasons comes back
>   either way. Only the month and day are used.
> - A window crossing new year (20 Dec → 10 Feb) keeps its length and is
>   labelled by the year it starts in, so a season isn't split in two.
> - Seasons whose start date hasn't arrived yet are left out.
> - Window capped at 366 days: it has to be a season, not several years.

One call for fourteen years.

**Same shape of change for the map.** Before, cell size was described as fixed:

> Cell size is picked automatically from the region's size — roughly 1 km
> cells for a single fire complex, coarser for a whole large country, and
> never finer than the dataset's native resolution.

After, the automatic choice is still described, and the manual one is new:

> ### Choosing the fire map's cell size — `resolution` (fires_viirs only)
>
> `resolution` is the cell size in degrees, one of `0.005, 0.01, 0.02, 0.05,
> 0.1, 0.2, 0.5, 1, 2, 5`. Anything else is an error listing these.
>
> Leave it out and the finest cell that still maps the whole region in one call
> is chosen, never finer than 0.1° …

## Why the flares section matters

An oil field burns gas every day of the year. NASA labels those detections, and
FactIQ now filters them out of every fires answer unless asked. Without the
doc, an agent writing about Basra or the Permian would report a permanent
wildfire. The new section says which default applies and when to override it.

It also covers the trap in the other direction: detections from the last few
weeks carry no label yet, and are counted as vegetation fires either way, so
the newest data is never quietly dropped.

## The SQL schema

`nasa_fires` is shaped unlike every other schema — no `series` table, no
`data_points` table, because a fire detection belongs to no series. The new
section in `references/data/schemas.md` names the five tables and the three
things that produce wrong numbers if you don't know them:

- The country total sits in `region_daily` as a row **beside** the state rows
  (`admin1_id = 0`), so summing everything double-counts.
- Grid cells are stored as `floor(degrees * 10)`, not as degrees.
- `type = -1` means NASA has not classified the detection yet, which is every
  detection from the last few weeks. A bare `type = 0` filter silently drops
  the newest data; the correct filter for wildfire and crop burning is
  `type IN (0, -1)`.

It also documents the one place the 50-row cap bends. A detection carries no
value to average, so sometimes the rows themselves are the answer, and
`run_sql` accepts `page` on this schema only. The skill repeats that in its
row-budget section so the agent doesn't assume `page` works everywhere.

## Files

| File | Change |
| --- | --- |
| `references/data/satellite.md` | New `seasons`, `resolution`, and `include_flares` sections; corrected fires lag, row budget, and window caps; `confidence` added to the points columns; two honesty notes |
| `references/data/schemas.md` | New `nasa_fires` table row, a section explaining its shape, and a routing bullet |
| `skills/factiq/SKILL.md` | Tool-table rows for `get_geo_data` and `run_sql`; the discovery and satellite workflow steps; the `page` exception in the row-budget section |
| `.claude-plugin/plugin.json` | 0.26.6 → 0.27.0 |
| `.codex-plugin/plugin.json` | 0.19.5 → 0.20.0, and the description now mentions satellite data, which it had never listed |

Both manifests point at the same `skills/` directory, so one docs change ships
to Claude Code and Codex alike. Only the version numbers are separate.

Tests pass (49).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
