### PR TITLE
Correct the fields listed for detailed earnings claim search

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, earnings-call transcripts, executive media appearances, a curated business-news feed, and satellite-derived data (nighttime lights, shipping and port activity, reservoir levels, crop fires and wildfires with mappable footprints, NO2/SO2/CO activity, smoke and dust aerosol, monsoon rainfall) — return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "author": {
     "name": "Defog"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real FactIQ data — official data, markets, earnings calls, executive media appearances, and satellite-derived signals including crop fires and wildfires — then return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "author": {
     "name": "Defog"
   },

--- a/references/report-patterns/earnings-intelligence.md
+++ b/references/report-patterns/earnings-intelligence.md
@@ -36,7 +36,7 @@ evidence management did not discuss a topic.
 
 | `search_target` | What `query` does | Applicable filters and returned detail |
 |---|---|---|
-| `claims` | Ranked lexical search; `query=""` browses rows | `company_filter`, exact `quarter_filter`, `claim_family` (primary or secondary family), `section`, `detail`, and `limit`. `detail=true` adds `structured_fields`, secondary families, period/horizon, conviction, denominator, and quantified/falsifiable flags. |
+| `claims` | Ranked lexical search; `query=""` browses rows | `company_filter`, exact `quarter_filter`, `claim_family` (primary or secondary family), `section`, `detail`, and `limit`. `detail=true` adds `structured_fields`, secondary families, period/horizon, conviction, denominator, and the `falsifiable` flag. |
 | `pressure_points` | Ranked lexical search; `query=""` browses Q&A pressure rows | `company_filter`, exact `quarter_filter`, `claim_family` (the linked family), `detail`, and `limit`. `section` is ignored because every row is Q&A. `detail=true` adds `tone_note`. |
 | `disclosure_profile` | No text search: direct company lookup | Uses the first ticker in `company_filter`, or `query` as the ticker. It is accumulated at company level. `quarter_filter` is ignored; `claim_family`, `section`, `detail`, and `limit` are also ignored. |
 | `coverage` | No theme search: corpus inventory | `company_filter` and `limit` apply. `query`, `quarter_filter`, `claim_family`, `section`, and `detail` do not narrow the inventory. |


### PR DESCRIPTION
`search_earnings_transcripts` no longer returns a `quantified` flag on claim rows. The reference still told the agent to expect one, so it is corrected here.

## Why the flag went away

It reported whether the extraction step had written anything into a claim's `value` field. The row already carries `value`, so the flag restated what the caller could see for itself.

It was also easy to misread. `quantified: true` looks like "this claim carries a hard number", but a value can be a spoken magnitude — "double-digit", "high teens %" — and the flag could not tell those apart from a precise figure. Look at `value` to judge that.

`falsifiable` is unchanged and still documented.

## Before

> `detail=true` adds `structured_fields`, secondary families, period/horizon, conviction, denominator, and quantified/falsifiable flags.

A claim row returned by `search_earnings_transcripts` with `detail=true`:

```json
{
  "claim_id": "...",
  "reporting_ticker": "MU",
  "value": "double-digit",
  "unit": "%",
  "denominator": "% of revenue",
  "conviction_qualifier": "confident",
  "time_horizon": "full year",
  "quantified": true,
  "falsifiable": true
}
```

## After

> `detail=true` adds `structured_fields`, secondary families, period/horizon, conviction, denominator, and the `falsifiable` flag.

The same row now:

```json
{
  "claim_id": "...",
  "reporting_ticker": "MU",
  "value": "double-digit",
  "unit": "%",
  "denominator": "% of revenue",
  "conviction_qualifier": "confident",
  "time_horizon": "full year",
  "falsifiable": true
}
```

Every other field is untouched.

## Versions

Both manifests are bumped so installs pick the correction up: `.claude-plugin` 0.27.0 to 0.27.1, `.codex-plugin` 0.20.0 to 0.20.1.