### PR TITLE
Update plugin clients and make visualization dependencies opt-in

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, earnings-call transcripts, executive media appearances, a curated business-news feed, and satellite-derived data (nighttime lights, shipping and port activity, reservoir levels, crop fires and wildfires with mappable footprints, NO2/SO2/CO activity, smoke and dust aerosol, monsoon rainfall) — return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "author": {
     "name": "Defog"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real FactIQ data — official data, markets, earnings calls, executive media appearances, and satellite-derived signals including crop fires and wildfires — then return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "author": {
     "name": "Defog"
   },

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FactIQ - a real-time finance and economy database for AI Agents
 
-Turn your agent into a finance and economy analyst. This plugin for
-[Claude Code](https://code.claude.com/docs/en/plugins) and
-[Codex](https://github.com/openai/codex) gives the agent direct access to
+Turn your agent into a finance and economy analyst. This plugin for Claude
+(web, desktop, and Cowork), ChatGPT Desktop, Claude Code, and Codex gives the
+agent direct access to
 FactIQ's warehouse of official statistics — SEC filings, US, China, India, Korea, IMF,
 World Bank, and more — plus live market data, earnings-call transcripts,
 executive media appearances, and satellite-derived data (fire detections,
@@ -20,6 +20,35 @@ teaches the agent a whole class of questions — see
 [Contributing](#contributing).
 
 ## Install
+
+FactIQ supports four client paths. The website guides are canonical for app
+setup and plan requirements, which can change faster than this repository:
+
+| Client | Supported surfaces | Setup guide |
+|---|---|---|
+| Claude | Web, desktop, and Cowork | [factiq.com/claude](https://www.factiq.com/claude) |
+| ChatGPT | Desktop app (including Codex in the app) | [factiq.com/chatgpt](https://www.factiq.com/chatgpt) |
+| Claude Code | CLI, desktop app, and IDE extensions | [factiq.com/claude-code](https://www.factiq.com/claude-code) |
+| Codex | CLI | [factiq.com/codex](https://www.factiq.com/codex) |
+
+### Claude (web, desktop, and Cowork)
+
+For the best experience, use Cowork. In Claude, open **Customize → Plugins**,
+add `defog-ai/factiq-plugin` as a personal marketplace, install FactIQ, and
+complete the browser sign-in. The full plugin requires a paid Claude plan;
+Claude Free can use the connector-only setup. See the
+[Claude guide](https://www.factiq.com/claude) for the current steps,
+organization-policy notes, and connector-only alternative.
+
+### ChatGPT Desktop
+
+In the ChatGPT desktop app, open **Plugins**, add
+`defog-ai/factiq-plugin` as a marketplace, install FactIQ from the Personal
+tab, and complete the browser sign-in. Custom plugins currently require a
+ChatGPT Pro, Business, Enterprise, or Edu plan. This installation also covers
+Codex inside the ChatGPT app; Codex CLI uses the separate setup below. See the
+[ChatGPT guide](https://www.factiq.com/chatgpt) for the current plan matrix and
+troubleshooting steps.
 
 ### Claude Code
 
@@ -125,8 +154,8 @@ Once installed and authenticated, ask a question:
 The agent finds the relevant series, runs the SQL, and replies with a
 shareable factiq.com chart link — or a terminal chart or full report,
 depending on what you ask for. You don't need the slash command: any
-economic or financial data question in a normal Claude Code or Codex
-conversation auto-invokes the skill.
+economic or financial data question in any supported client auto-invokes the
+skill.
 
 For an earnings question such as "What did Micron management say on its latest
 call?", the skill checks live transcript coverage first, pins the exact fiscal
@@ -150,6 +179,7 @@ authors a local output. Data access uses the **FactIQ MCP server** bundled in
 
 ```
 ┌─────────────────────────────┐
+│  Claude / ChatGPT /         │
 │  Claude Code / Codex        │
 │  + factiq skill (SKILL.md)  │      the agent orchestrates everything
 └──────────────┬──────────────┘
@@ -205,7 +235,7 @@ returns the live, authoritative version.
 Where the behavior lives — the files contributors will touch:
 
 - `skills/factiq/SKILL.md` — the skill definition and single source of truth
-  for the workflow. Auto-discovered by both Claude Code and Codex from the
+  for the workflow. Auto-discovered by supported plugin clients from the
   `skills/` directory
 - `references/data/` — the data layer: SQL idioms (`sql-guide.md`) and the
   dataset schema overview (`schemas.md`)
@@ -223,16 +253,17 @@ Where the behavior lives — the files contributors will touch:
   FactIQ ChartSpec and report JSON objects. It supports bar, simple line, and
   table fallback renderers
 - `scripts/build_viz.py` — local-only tool that assembles fetched data into a
-  self-contained HTML viz and screenshots it headless for iteration; usage in
-  [`references/output/viz-guide.md`](references/output/viz-guide.md)
+  self-contained HTML viz and screenshots it headless for iteration. It never
+  installs Playwright or Chromium unless `--install-deps` is explicitly
+  passed; usage in [`references/output/viz-guide.md`](references/output/viz-guide.md)
 - `assets/viz-shell.html` — starting-point shell for bespoke visualizations
 
 Plugin plumbing — you shouldn't need to touch these:
 
 - `.mcp.json` — declares the bundled FactIQ MCP server (Streamable HTTP,
   OAuth). Read by both Claude Code and Codex plugin loaders
-- `.claude-plugin/` — Claude Code plugin + marketplace manifests
-- `.codex-plugin/` — Codex plugin manifest
+- `.claude-plugin/` — Claude and Claude Code plugin + marketplace manifests
+- `.codex-plugin/` — ChatGPT and Codex plugin manifest
 - `.agents/plugins/marketplace.json` — Codex marketplace entry for
   `codex plugin marketplace add defog-ai/factiq-plugin`
 

--- a/references/output/viz-guide.md
+++ b/references/output/viz-guide.md
@@ -21,11 +21,17 @@ caller's working directory:
 |---|---|
 | `save --out F.json [--tool run_sql] [--match STR] [--index N] [--list]` | Copy a tool result's **raw JSON straight from the harness transcript** to `F.json` — the shell does the byte copy, you never retype the data. Feeds `assemble --data`. Stdlib only. See **Saving data without retyping** below. |
 | `assemble --template T --data k1=f1.json k2=f2.json … --out O.html [--open]` | Inject on-disk JSON into your HTML at the `__FACTIQ_DATA__` marker; write one portable file. Stdlib only. Pass **all** key=path pairs after the single `--data` flag (or repeat the flag — both work). |
-| `render H.html [--out P.png] [--width] [--height] [--full-page] [--selector CSS] [--wait MS]` | Screenshot the file in headless Chromium and report JS/console errors + failed requests. Installs Playwright + Chromium into `~/.factiq/viz-venv` on first run. |
+| `render H.html [--out P.png] [--width] [--height] [--full-page] [--selector CSS] [--wait MS] [--install-deps]` | Screenshot the file in headless Chromium and report JS/console errors + failed requests. Does not install anything by default. `--install-deps` explicitly allows installation of Playwright + Chromium into `~/.factiq/viz-venv`. |
 
 `render` exits **5** when the page logged a JS error, an uncaught exception,
 or a failed asset request — treat a non-zero exit as "the viz is broken, read
 stderr," not "minor warning."
+
+If Playwright or Chromium is unavailable, `render` exits **6** without
+installing anything. Never add `--install-deps` unless the user explicitly
+authorizes the local dependency download. Without approval, keep the assembled
+HTML, render the same findings as a terminal chart or table with
+`term_chart.py`, and disclose that the HTML was not screenshot-verified.
 
 ## The workflow
 
@@ -58,6 +64,10 @@ stderr," not "minor warning."
    ```bash
    python3 "{plugin_root}/scripts/build_viz.py" render /tmp/out.html --out /tmp/out.png
    ```
+   On a machine without the rendering dependencies, ask before installing
+   them. Only after explicit approval, rerun the command with
+   `--install-deps`; otherwise use the terminal/table fallback described
+   above.
    If exit code is 5, read the errors on stderr and fix them first — a JS
    error usually means a blank page. Then inspect the screenshot against the
    legibility checklist below and iterate: edit → assemble → render → look,

--- a/scripts/build_viz.py
+++ b/scripts/build_viz.py
@@ -13,8 +13,9 @@ Two subcommands:
   assemble  — inject on-disk JSON into an HTML template at the data marker,
               producing one portable, self-contained .html. Stdlib only.
   render    — open an HTML file in headless Chromium, write a PNG, and report
-              any JS/console errors and failed requests. Needs Playwright;
-              installs the package and Chromium on first run.
+              any JS/console errors and failed requests. Needs Playwright and
+              Chromium; installs them only with the explicit --install-deps
+              opt-in flag.
 
 Data contract: the template must contain the marker token __FACTIQ_DATA__
 inside a JSON script tag (see assets/viz-shell.html). After assembly the page
@@ -414,15 +415,25 @@ def _venv_has_playwright(venv_py: str) -> bool:
     )
 
 
-def _ensure_render_env():
+def _missing_render_dependency(name: str) -> None:
+    fail(
+        f"{name} is required for headless rendering, but FactIQ did not install "
+        "anything. After the user explicitly approves the local dependency "
+        "download, rerun the render command with --install-deps. Without "
+        "approval, keep the HTML output and use the terminal/table fallback.",
+        6,
+    )
+
+
+def _ensure_render_env(install_deps: bool):
     """Return sync_playwright, or re-exec this script under a dedicated venv.
 
     The interpreter that launched us may be externally managed (Homebrew, uv,
-    distro python) where `pip install` is refused. Rather than touch it, we
-    keep a private venv at ~/.factiq/viz-venv, install Playwright there, and
-    re-exec the same command under that venv's python. Chromium itself is
-    installed lazily by the launch fallback in cmd_render, now running under
-    the venv.
+    distro python) where `pip install` is refused. When dependency installation
+    was explicitly opted into, keep a private venv at ~/.factiq/viz-venv,
+    install Playwright there, and re-exec the same command under that venv's
+    python. Chromium itself is installed by the launch fallback in cmd_render,
+    also only after that opt-in.
     """
     try:
         from playwright.sync_api import sync_playwright  # noqa: F401
@@ -435,6 +446,14 @@ def _ensure_render_env():
         fail("Playwright is unavailable even after venv setup.", 6)
 
     venv_py = _venv_python(VENV_DIR)
+    if os.path.exists(venv_py) and _venv_has_playwright(venv_py):
+        env = dict(os.environ, FACTIQ_VIZ_REEXEC="1")
+        os.execve(venv_py, [venv_py, os.path.abspath(__file__), *sys.argv[1:]], env)
+        return None
+
+    if not install_deps:
+        _missing_render_dependency("Playwright")
+
     # Prefer uv when present: the interpreter that launched us is often a
     # uv-managed build with no ensurepip, so stdlib `venv --with-pip` aborts.
     # uv creates the venv and installs into it without needing pip bootstrapped.
@@ -492,25 +511,30 @@ def _install_chromium() -> None:
         fail(f"Failed to install Chromium: {exc}", 6)
 
 
+def _launch_chromium(chromium, install_deps: bool):
+    try:
+        return chromium.launch()
+    except Exception as exc:  # missing browser binary
+        msg = str(exc).lower()
+        if "install" not in msg and "executable doesn't exist" not in msg:
+            raise
+        if not install_deps:
+            _missing_render_dependency("Chromium")
+        _install_chromium()
+        return chromium.launch()
+
+
 def cmd_render(args: argparse.Namespace) -> None:
     html_path = os.path.abspath(args.html)
     if not os.path.exists(html_path):
         fail(f"No such HTML file: {html_path}")
     out = os.path.abspath(args.out) if args.out else os.path.splitext(html_path)[0] + ".png"
 
-    sync_playwright = _ensure_render_env()
+    sync_playwright = _ensure_render_env(args.install_deps)
 
     errors: list[str] = []
     with sync_playwright() as p:
-        try:
-            browser = p.chromium.launch()
-        except Exception as exc:  # missing browser binary on first run
-            msg = str(exc).lower()
-            if "install" in msg or "executable doesn't exist" in msg:
-                _install_chromium()
-                browser = p.chromium.launch()
-            else:
-                raise
+        browser = _launch_chromium(p.chromium, args.install_deps)
         try:
             page = browser.new_page(
                 viewport={"width": args.width, "height": args.height},
@@ -635,6 +659,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--scale", type=float, default=2.0, help="Device scale factor (default 2)")
     p.add_argument("--full-page", action="store_true", help="Capture the full scrollable page")
     p.add_argument("--selector", help="Screenshot only the element matching this CSS selector")
+    p.add_argument(
+        "--install-deps",
+        action="store_true",
+        help="Explicitly allow installing Playwright and Chromium under "
+        "~/.factiq/viz-venv when missing",
+    )
     p.add_argument(
         "--wait",
         type=int,

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -583,7 +583,7 @@ the API):
 |---|---|
 | `save --out F.json [--tool run_sql] [--match STR] [--index N] [--list]` | Copy a tool result's **raw JSON from the harness transcript** to `F.json` — the shell copies the bytes, you never retype the data. Feeds `assemble --data`. Stdlib only. |
 | `assemble --template T.html --data k1=f1.json k2=f2.json … --out O.html [--open]` | Inject on-disk JSON into your HTML at the `__FACTIQ_DATA__` marker; write one portable, self-contained file. Stdlib only. List **all** key=path pairs after the one `--data` flag. |
-| `render O.html [--out P.png] [--width N] [--height N] [--full-page] [--selector CSS] [--wait MS]` | Screenshot the file in headless Chromium and report JS/console errors + failed asset loads. Installs Playwright + Chromium into `~/.factiq/viz-venv` on first run (uses `uv` if available, else a stdlib venv). |
+| `render O.html [--out P.png] [--width N] [--height N] [--full-page] [--selector CSS] [--wait MS] [--install-deps]` | Screenshot the file in headless Chromium and report JS/console errors + failed asset loads. Does not install anything by default. `--install-deps` explicitly allows Playwright + Chromium installation into `~/.factiq/viz-venv` (using `uv` if available, else a stdlib venv). |
 
 The loop that makes this work — **fetch → save → author → assemble → render →
 look → fix**:
@@ -611,7 +611,12 @@ look → fix**:
 3. `assemble` the self-contained file, then `render` it and **actually read the
    screenshot**. `render` exits **5** when the page logged a JS error or a
    failed request — that usually means a blank page; fix it before judging the
-   visual. One render pass is never enough; budget two or three.
+   visual. One render pass is never enough; budget two or three. If `render`
+   reports that Playwright or Chromium is missing, **do not pass
+   `--install-deps` unless the user explicitly authorizes the local dependency
+   download**. Without that authorization, keep the assembled HTML, use
+   `term_chart.py` to return a terminal/table preview of the same findings, and
+   explain that the HTML was not screenshot-verified.
 4. Hand the user the local file path; offer `--open` to open it in a browser.
 
 If the viz will instead be published as a **claude.ai Artifact** that calls

--- a/tests/test_build_viz_install_opt_in.py
+++ b/tests/test_build_viz_install_opt_in.py
@@ -1,0 +1,128 @@
+import contextlib
+import importlib.util
+import io
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "build_viz", ROOT / "scripts" / "build_viz.py"
+)
+assert SPEC and SPEC.loader
+build_viz = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(build_viz)
+
+
+class DocumentationContractTests(unittest.TestCase):
+    def test_readme_names_all_supported_clients_and_canonical_guides(self):
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+        for expected in (
+            "Claude (web, desktop, and Cowork)",
+            "ChatGPT Desktop",
+            "https://www.factiq.com/claude",
+            "https://www.factiq.com/chatgpt",
+            "https://www.factiq.com/claude-code",
+            "https://www.factiq.com/codex",
+        ):
+            self.assertIn(expected, readme)
+
+    def test_public_guidance_requires_explicit_install_opt_in(self):
+        for relative_path in (
+            "README.md",
+            "skills/factiq/SKILL.md",
+            "references/output/viz-guide.md",
+        ):
+            text = (ROOT / relative_path).read_text(encoding="utf-8")
+            self.assertIn("--install-deps", text)
+            self.assertNotIn("Installs Playwright + Chromium", text)
+
+
+class RenderDependencyOptInTests(unittest.TestCase):
+    def test_install_deps_is_off_by_default_and_requires_a_flag(self):
+        parser = build_viz.build_parser()
+
+        default = parser.parse_args(["render", "viz.html"])
+        opted_in = parser.parse_args(["render", "viz.html", "--install-deps"])
+
+        self.assertFalse(default.install_deps)
+        self.assertTrue(opted_in.install_deps)
+
+    def test_missing_playwright_does_not_run_install_commands_without_opt_in(self):
+        real_import = __import__
+
+        def import_without_playwright(name, *args, **kwargs):
+            if name == "playwright.sync_api":
+                raise ImportError("not installed")
+            return real_import(name, *args, **kwargs)
+
+        stderr = io.StringIO()
+        with (
+            mock.patch("builtins.__import__", side_effect=import_without_playwright),
+            mock.patch.object(build_viz.os.path, "exists", return_value=False),
+            mock.patch.object(build_viz.subprocess, "run") as run,
+            mock.patch.object(build_viz.os, "execve") as execve,
+            contextlib.redirect_stderr(stderr),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            build_viz._ensure_render_env(install_deps=False)
+
+        self.assertEqual(raised.exception.code, 6)
+        run.assert_not_called()
+        execve.assert_not_called()
+        self.assertIn("did not install anything", stderr.getvalue())
+        self.assertIn("--install-deps", stderr.getvalue())
+
+    def test_existing_factiq_render_environment_is_reused_without_opt_in(self):
+        real_import = __import__
+
+        def import_without_playwright(name, *args, **kwargs):
+            if name == "playwright.sync_api":
+                raise ImportError("not installed")
+            return real_import(name, *args, **kwargs)
+
+        with (
+            mock.patch("builtins.__import__", side_effect=import_without_playwright),
+            mock.patch.object(build_viz.os.path, "exists", return_value=True),
+            mock.patch.object(build_viz, "_venv_has_playwright", return_value=True),
+            mock.patch.object(build_viz.os, "execve") as execve,
+        ):
+            build_viz._ensure_render_env(install_deps=False)
+
+        execve.assert_called_once()
+
+    def test_missing_chromium_is_not_installed_without_opt_in(self):
+        chromium = mock.Mock()
+        chromium.launch.side_effect = RuntimeError("Executable doesn't exist")
+        stderr = io.StringIO()
+
+        with (
+            mock.patch.object(build_viz, "_install_chromium") as install,
+            contextlib.redirect_stderr(stderr),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            build_viz._launch_chromium(chromium, install_deps=False)
+
+        self.assertEqual(raised.exception.code, 6)
+        install.assert_not_called()
+        self.assertIn("terminal/table fallback", stderr.getvalue())
+
+    def test_missing_chromium_can_be_installed_after_opt_in(self):
+        browser = object()
+        chromium = mock.Mock()
+        chromium.launch.side_effect = [
+            RuntimeError("Executable doesn't exist"),
+            browser,
+        ]
+
+        with mock.patch.object(build_viz, "_install_chromium") as install:
+            result = build_viz._launch_chromium(chromium, install_deps=True)
+
+        install.assert_called_once_with()
+        self.assertIs(result, browser)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- document Claude web/desktop/Cowork and ChatGPT Desktop support, with canonical FactIQ setup-guide links
- make Playwright and Chromium installation explicitly opt-in via `--install-deps`
- reuse an existing FactIQ visualization environment without reinstalling, and fail gracefully to terminal/table guidance when dependencies are unavailable
- add regression coverage and bump the Claude/Codex plugin patch versions

## Why

Addresses DEF-1508. The README predated the newer desktop client support, while the bespoke visualization renderer silently created `~/.factiq/viz-venv` and downloaded Playwright/Chromium on first use.

## User impact

Plugin users can see all supported installation paths in the README. Rendering no longer mutates the local environment unless the user explicitly approves the dependency download; users without those dependencies still receive a clear fallback path.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py'` — 55 tests passed
- verified a missing-Playwright render exits 6 without installing anything
- `python3 -m compileall -q scripts tests`
- validated both plugin manifests with `python3 -m json.tool`
- `git diff --cached --check`
