### PR TITLE
Report missing company fundamentals and transcript coverage

### DIFF
--- a/references/report-patterns/earnings-intelligence.md
+++ b/references/report-patterns/earnings-intelligence.md
@@ -28,9 +28,16 @@ consistent with the data", "who mentioned <theme> this quarter".
 the authoritative coverage window; do not rely on a static assumption about
 how many calls exist. If a ticker is not covered, say so and fall back to the
 `sec` schema plus `get_market_data`; never silently substitute filed data for
-spoken remarks.
+spoken remarks. Also file `send_feedback` with `category="missing_data"`, naming
+only the ticker and the observed missing transcript coverage. If the ticker is
+covered but the user requested an exact fiscal period, confirm it with an
+empty-query call using that ticker + exact `quarter_filter`; if that call shows
+the period is absent, report the ticker, exact period, and observed missing
+coverage with the same category.
 An uncovered period, an empty lexical result, or a partial result is never
-evidence management did not discuss a topic.
+evidence management did not discuss a topic. In particular, do not file
+`missing_data` solely because a topical or lexical search has no matches for a
+ticker and fiscal period that do have coverage.
 
 ## Target and Filter Reference
 

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -203,7 +203,7 @@ read `references/report-patterns/media-intelligence.md` before searching.
 
 | Tool | Purpose |
 |---|---|
-| `send_feedback` (`message`, `category?`) | Report a problem to the FactIQ team: `category` is `"data_issue"` (a value that contradicts the official source, wrong units/scale, duplicated or missing periods), `"tool_error"` (a tool that errors or returns malformed results), `"missing_data"` (advertised but empty, or coverage ends too early), or `"other"`. Returns an acknowledgment. |
+| `send_feedback` (`message`, `category?`) | Report a problem to the FactIQ team: `category` is `"data_issue"` (a value that contradicts the official source, wrong units/scale, duplicated or missing periods), `"tool_error"` (a tool that errors or returns malformed results), `"missing_data"` (advertised but empty, coverage ends too early, or company fundamentals/transcript coverage is absent), or `"other"`. Returns an acknowledgment. |
 
 Use it on your own initiative whenever something looks broken — don't wait for
 the user to complain. Write one short, specific message with the concrete
@@ -212,6 +212,24 @@ vs. observed, the official source's value or URL if you have one). Don't
 include the user's personal details or your conversation. It's one-way — the
 team reviews every report, but nothing comes back — so file it and continue
 with the task; never block on it.
+
+Company-coverage gaps require `category="missing_data"`:
+
+- **Fundamentals:** if `get_market_data` for a named ticker returns no usable
+  company fundamentals after its supported WorldDB database, cache, and
+  provider lookup has completed, report the ticker, exact requested function
+  (`OVERVIEW`, `INCOME_STATEMENT`, `BALANCE_SHEET`, `CASH_FLOW`, or `EARNINGS`),
+  and the observed empty or missing result.
+- **Earnings transcripts:** check `search_target="coverage"` first. Report a
+  named ticker that is absent from coverage, or a requested fiscal period that
+  an empty-query call with the exact ticker + `quarter_filter` confirms is
+  absent. Include only the ticker, exact period, and observed missing coverage.
+  Do **not** report `missing_data` solely because a topical or lexical query has
+  no matches when that ticker and period have transcript coverage; retry the
+  company's vocabulary and describe the bounded retrieval result instead.
+
+Do not add personal details or conversation content to either report. A Slack
+delivery failure does not change the rule: continue the original task.
 
 ### Terminal charts — `term_chart.py`
 

--- a/tests/test_earnings_docs.py
+++ b/tests/test_earnings_docs.py
@@ -89,6 +89,47 @@ class EarningsDocumentationContractTests(unittest.TestCase):
         self.assertIn("exact quarter", cross_company)
         self.assertIn("calendar_date", cross_company)
 
+    def test_missing_company_coverage_is_reported_without_false_positives(self):
+        feedback = SKILL.split("### Feedback", 1)[1].split(
+            "### Terminal charts", 1
+        )[0]
+        normalized_feedback = " ".join(feedback.split())
+        normalized_playbook = " ".join(PLAYBOOK.split())
+
+        self.assertIn('category="missing_data"', normalized_feedback)
+        self.assertIn(
+            "supported WorldDB database, cache, and provider lookup",
+            normalized_feedback,
+        )
+        for function in (
+            "OVERVIEW",
+            "INCOME_STATEMENT",
+            "BALANCE_SHEET",
+            "CASH_FLOW",
+            "EARNINGS",
+        ):
+            self.assertIn(f"`{function}`", normalized_feedback)
+        self.assertIn('search_target="coverage"', normalized_feedback)
+        self.assertIn("exact ticker + `quarter_filter`", normalized_feedback)
+        self.assertIn(
+            "ticker, exact period, and observed missing coverage",
+            normalized_feedback,
+        )
+        self.assertIn("topical or lexical query", normalized_feedback)
+        self.assertIn("Slack delivery failure", normalized_feedback)
+        self.assertIn(
+            "personal details or conversation content", normalized_feedback
+        )
+
+        self.assertIn(
+            'send_feedback` with `category="missing_data"', normalized_playbook
+        )
+        self.assertIn(
+            "empty-query call using that ticker + exact `quarter_filter`",
+            normalized_playbook,
+        )
+        self.assertIn("do not file `missing_data` solely", normalized_playbook)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Slack request

[Open the original Slack request](https://defog-ai.slack.com/archives/C0BQM5EN5CM/p1787332681843349)

<pre>When an agent asks for a stock fundamentals or earnings transcript but we don&#x27;t have data for it - we should get a message in &lt;#C05994Z3LQG&gt; channel. The bug reports worker can then use the existing ways we have of getting transcripts and fundamental data, and then acquire that data + add to DB</pre>

## Acceptance criteria

- Missing named-ticker fundamentals after supported database, cache, and provider lookup triggers send_feedback with category "missing_data".
- Missing ticker or requested fiscal-period transcript coverage triggers missing_data feedback; empty topical or lexical searches within existing coverage do not.
- Feedback identifies only the ticker, requested function or fiscal period, and observed missing result, without personal details or conversation content.
- The existing SLACK_FEEDBACK_CHANNEL delivery path remains non-blocking and is covered by existing delivery tests.
- Backend MCP instructions and factiq-plugin skill/reference guidance are synchronized and regression-tested.

## Change

Added synchronized backend and plugin guidance that files missing_data feedback for genuine company fundamentals or transcript coverage gaps, while excluding empty topical searches. Existing configured, non-blocking Slack delivery remains unchanged.

## Before and after

### Same acceptance input

- **Before (`08143cf66570cab06da8f02b7b6b0d4ac3ecef06`):** `python3 -m unittest tests.test_earnings_docs.EarningsDocumentationContractTests.test_missing_company_coverage_is_reported_without_false_positives` returned non-zero when the candidate's regression test was applied to the unchanged base.
- **After (candidate):** the same `python3 -m unittest tests.test_earnings_docs.EarningsDocumentationContractTests.test_missing_company_coverage_is_reported_without_false_positives` input passed.

### Changed surfaces

- `skills/factiq/SKILL.md`
- `references/report-patterns/earnings-intelligence.md`
- `tests/test_earnings_docs.py`

### Verified candidate behavior

- Proves plugin skill and earnings-reference guidance enforce the new reporting rules.
- Runs the complete plugin test suite; 56 tests passed.
- Checks the documentation and test diff for whitespace errors.

## Verification

The generated acceptance test failed on the base and passed with this change.

- `python3 -m unittest tests.test_earnings_docs.EarningsDocumentationContractTests.test_missing_company_coverage_is_reported_without_false_positives` — Proves plugin skill and earnings-reference guidance enforce the new reporting rules.
- `python3 -m unittest discover -s tests` — Runs the complete plugin test suite; 56 tests passed.
- `git diff --check` — Checks the documentation and test diff for whitespace errors.

The host verified this repository from base `08143cf66570cab06da8f02b7b6b0d4ac3ecef06` and an independent read-only Codex review approved the coordinated diff.

## Review notes

- Non-blocking scope limitation: routers/mcp/publish_gate.py:34-42 and 89-104 intentionally hide both the new guidance and send_feedback tool from the listed ChatGPT connector. The behavior is available to the FactIQ plugin, Claude, Codex, and raw authenticated clients.

## Coordinated pull requests

- `worlddb`: https://github.com/defog-ai/worlddb/pull/1352

## Safety

- Codex had no GitHub, Slack, SSH, production-write, billing, or signing credentials.
- Production database access inside the agent was read-only.
- Publication was performed by the trusted host after verification.

Generated autonomously by the FactIQ Slack worker.
