### PR TITLE
Publish bespoke HTML reports through FactIQ MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ air-quality activity signals,
 rainfall, nighttime lights, shipping and port activity, reservoir levels).
 The agent discovers series, runs read-only SQL, computes derived metrics, and
 returns a sourced answer, terminal preview, report JSON, or bespoke local HTML
-visualization.
+visualization. Writable clients can also publish bespoke HTML to a sandboxed
+FactIQ `/share/{share_id}` page without retranscribing the source data rows.
 
 No codebase or hosted database is required — only a free
 [FactIQ account](https://factiq.com).
@@ -192,6 +193,7 @@ authors a local output. Data access uses the **FactIQ MCP server** bundled in
 │  fetch      run_sql (read-only), get_series, get_market_data,
 │             search_company_filings, search_earnings_transcripts,
 │             search_media_appearances, search_news
+│  publish    publish_html_report (writable clients; immutable data refs)
 └──────────────┬──────────────┘
                │
 ┌──────────────▼──────────────┐

--- a/assets/viz-shell.html
+++ b/assets/viz-shell.html
@@ -8,7 +8,9 @@
   After assembly a global `DATA` object is available, keyed by the names you pass
   to `build_viz.py assemble --data <key>=<file.json>`. Each value is the full
   factiq payload, so SQL/series rows live at DATA.<key>.results (columns at
-  DATA.<key>.columns). Load any library you need from a CDN in <head>.
+  DATA.<key>.columns). `factiqData(key)` reads that same local preview data, or
+  fetches ./data/<key>.json when this unassembled template is published through
+  FactIQ. Load any library you need from a CDN in <head>.
 -->
 <html lang="en">
   <head>
@@ -58,11 +60,18 @@ __FACTIQ_DATA__
     </div>
 
     <script>
-      // The single, library-agnostic entry point. `DATA` is whatever you
-      // injected; rows are typically at DATA.<key>.results.
-      const DATA = JSON.parse(
-        document.getElementById("factiq-data").textContent
-      );
+      // Local previews contain assembled JSON. Published templates retain the
+      // marker and load immutable report-scoped JSON by key instead.
+      const factiqDataText = document.getElementById("factiq-data").textContent.trim();
+      const DATA = factiqDataText === "__FACTIQ_DATA__"
+        ? {}
+        : JSON.parse(factiqDataText);
+      async function factiqData(key) {
+        if (Object.prototype.hasOwnProperty.call(DATA, key)) return DATA[key];
+        const response = await fetch(`./data/${encodeURIComponent(key)}.json`);
+        if (!response.ok) throw new Error(`FactIQ data ${key} failed (${response.status})`);
+        return response.json();
+      }
 
       // --- author your visualization below ---
     </script>

--- a/commands/ask.md
+++ b/commands/ask.md
@@ -27,6 +27,10 @@ Codex: `codex mcp login factiq`), then retry.
   narrative. Use for one metric, trend, or comparison.
 - **Detailed report** — a local multi-section report with summary, charts,
   methodology notes, and terminal previews. Use for broad analytical requests.
+- **Published bespoke report** — custom HTML rendered locally against exact
+  transcript-saved tool results, then published with `publish_html_report`
+  using only `_factiq_data_ref` mappings. Use when the user asks for a hosted
+  FactIQ report or share URL; follow `references/output/publish-html-report.md`.
 
 If the question clearly fits one mode, proceed without asking. Only when it
 is genuinely ambiguous — broad enough that a report would add value, but a

--- a/references/output/publish-html-report.md
+++ b/references/output/publish-html-report.md
@@ -1,0 +1,99 @@
+# Publish a bespoke HTML report to FactIQ
+
+Writable FactIQ MCP clients expose `publish_html_report`. Configured read-only
+connectors do not list or accept it. The tool returns the canonical
+`https://www.factiq.com/share/{share_id}` URL.
+
+Use this for a bespoke report that should live on FactIQ rather than only as a
+local file. Existing structured report JSON remains a separate local output.
+
+## Contract and limits
+
+Every eligible FactIQ data-tool result includes:
+
+```json
+"_factiq_data_ref": {
+  "id": "opaque-reference-id",
+  "expires_at": "2026-08-23T12:00:00+00:00"
+}
+```
+
+The reference belongs to the authenticated user and expires after 24 hours.
+`publish_html_report` accepts only:
+
+- `question`: the report title/question, at most 2,000 characters;
+- `html`: one complete UTF-8 HTML document, at most 1,000,000 bytes;
+- `data_assets`: at most 12 `{key, ref_id}` mappings, at most 1,000,000 JSON
+  bytes total;
+- `model`: an optional author/model label, at most 100 characters.
+
+Keys start with a letter and contain only letters, digits, `_`, or `-`. A key
+named `jobs` is available inside the published page at `./data/jobs.json`.
+FactIQ validates every reference and copies the exact prior MCP result bytes
+into immutable, report-scoped JSON assets in the same transaction as the HTML.
+Missing, expired, or another user's references make the entire publish call
+fail; no partial public page is created.
+
+## Complete workflow
+
+1. Fetch with `run_sql`, `get_series`, or another FactIQ data tool. Keep each
+   returned `_factiq_data_ref.id`; do not copy its `results` rows into a later
+   model-authored payload.
+2. Immediately save each exact tool result locally for authoring and preview:
+
+   ```bash
+   python3 "{plugin_root}/scripts/build_viz.py" save \
+     --tool run_sql --match "distinctive SQL fragment" --out /tmp/jobs.json
+   ```
+
+   `save` copies the harness transcript bytes. Never recreate the JSON with
+   Write, a heredoc, or model-generated row arrays.
+3. Copy `assets/viz-shell.html` to a report template. Read each dataset with the
+   shell's asynchronous loader:
+
+   ```js
+   const jobs = await factiqData("jobs");
+   const rows = jobs.results;
+   ```
+
+   The checked-in shell has two modes. An assembled local preview reads `jobs`
+   from its injected `DATA`; the original unassembled template sees the
+   `__FACTIQ_DATA__` marker and fetches `./data/jobs.json`. Do not paste rows
+   into the HTML.
+4. Assemble and locally render the preview against the exact saved files:
+
+   ```bash
+   python3 "{plugin_root}/scripts/build_viz.py" assemble \
+     --template report-template.html \
+     --data jobs=/tmp/jobs.json markets=/tmp/markets.json \
+     --out /tmp/report-preview.html
+   python3 "{plugin_root}/scripts/build_viz.py" render \
+     /tmp/report-preview.html --out /tmp/report-preview.png
+   ```
+
+   Inspect the PNG and iterate until the report is readable at its target
+   width. Publish the **unassembled template**, not `report-preview.html`; the
+   assembled preview contains local data by design.
+5. Call `publish_html_report` once with the unassembled template text and the
+   references from step 1:
+
+   ```json
+   {
+     "question": "What changed in the labor market?",
+     "html": "<the unassembled report-template.html text>",
+     "data_assets": [
+       {"key": "jobs", "ref_id": "<run_sql _factiq_data_ref.id>"},
+       {"key": "markets", "ref_id": "<get_market_data _factiq_data_ref.id>"}
+     ],
+     "model": "the current model name"
+   }
+   ```
+
+   Verify that neither the HTML nor the publish arguments contains a source
+   result row. Return the `share_url` from the tool response to the user.
+
+Published HTML executes in a sandboxed iframe without FactIQ cookie/storage,
+parent-DOM, or top-navigation access. It may run scripts and fetch its own
+immutable report-scoped JSON assets. For responsive height, the report can
+send `parent.postMessage({type: "factiq-report-height", height: document.documentElement.scrollHeight}, "*")`;
+FactIQ bounds the accepted height.

--- a/references/output/viz-guide.md
+++ b/references/output/viz-guide.md
@@ -11,6 +11,11 @@ layout, a multi-panel dashboard, a force/flow/chord diagram, an annotated
 narrative, a novel encoding, an interactive cross-filtered view, or just
 fine-grained control over a chart's look.
 
+When the user wants a hosted FactIQ share instead of only a local file, use the
+same author/render loop and then follow `publish-html-report.md`. Publish the
+unassembled template with `_factiq_data_ref` mappings; never publish the
+assembled preview because it contains the locally injected result rows.
+
 ## The three commands
 
 `{plugin_root}/scripts/build_viz.py` is local-only (it never calls the FactIQ
@@ -184,15 +189,21 @@ anywhere else — an HTML comment, a `<div>`, the wrong id — and
 `Cannot read properties of null (reading 'textContent')` and a blank page.
 (Starting from `assets/viz-shell.html` gives you the element for free.)
 
-After `assemble`, the page exposes one global:
+After `assemble`, the page exposes one global and one loader:
 
 ```js
 const DATA = JSON.parse(document.getElementById("factiq-data").textContent);
+const jobs = await factiqData("jobs");
 ```
 
 `DATA[key]` is the **full FactIQ payload** for the file you passed as
 `--data key=file.json` — i.e. exactly the `run_sql` / `get_series` tool result
 you saved to that file:
+
+In the checked-in shell, `factiqData(key)` returns `DATA[key]` in an assembled
+local preview. In an unassembled template published through FactIQ, it instead
+fetches the immutable `./data/{key}.json` asset. Author hosted-capable reports
+against `factiqData(key)` while using `DATA` only in local-only recipes.
 
 - `run_sql` results: `DATA.key.results` is an array of **positional arrays**
   aligned to `DATA.key.columns` (e.g. `["DC", 5.5, "2026-04-01"]`), *not* an

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -45,11 +45,13 @@ Four output modes:
   charts, methodology, and terminal previews. Use for broad analytical
   questions. Covered domains route through `references/report-patterns/README.md`.
   If scope is unclear, use `references/report-patterns/interview-step.md` first.
-- **Bespoke local viz** (`build_viz.py`) — a self-contained HTML file you
+- **Bespoke local or published viz** (`build_viz.py`) — a self-contained HTML file you
   author freely and save locally. Use when the answer
   needs something the ChartSpec can't express: a custom layout, a multi-panel
   dashboard, a force/flow/chord diagram, a novel encoding, or fine-grained
-  visual control. See **Bespoke local visualizations** below.
+  visual control. Keep it local by default; when the user asks for a FactIQ
+  link, publish it with `publish_html_report`. See **Bespoke local
+  visualizations** below and `references/output/publish-html-report.md`.
 
 **Data in, output out:**
 
@@ -123,6 +125,11 @@ All FactIQ tools are MCP tools provided by the `factiq` MCP server.
 | `search_media_appearances` (`query`, `search_target?`, `company_filter?`, `person?`, `sort?`, `appearance_type?`, `claim_family?`, `date_from?`, `date_to?`, `detail?`, `limit?`) | Deterministic, lexical retrieval over precomputed public-safe paraphrases of what executives said outside earnings calls; **no serving-time model** interprets or expands the query. Strict lexical FTS runs first, loose any-term FTS only when strict finds no candidates, and trigram fallback only when both FTS stages are empty. Prefer concise topical language and retry company-native synonyms before concluding silence. Canonical targets are `search` (default claims + passages blend), `claims`, `passages`, `pressure_points`, `appearances`, and `coverage`; compatibility aliases `all`, `videos`, and `companies` map respectively to `search`, `appearances`, and `coverage` and are not recommended for new calls. `sort="relevance"` ranks lexical score before publication date; `sort="newest"` ranks publication date before lexical score. `company_filter` accepts comma-separated primary tickers; `person` is a case-insensitive speaker-name substring; `appearance_type`, `claim_family`, inclusive `date_from`/`date_to`, `detail`, and `limit` provide further narrowing. Dates are the video's publication/upload date, not necessarily its recording/event date. `claim_family` makes blended search claims-only, is invalid with `passages`, and requires matching claims for catalog targets. Structured finding rows expose `result_kind`, `canonical_paraphrase`, speaker/topic/video metadata, relevance, and a timestamped YouTube URL; `appearances` returns video-level metadata, attribution, matching-claim count, URL, and relevance; `coverage` returns company-level structured corpus counts and date/channel inventory. `detail=true` adds normalized claim/attribution fields to finding rows, but never raw transcript text or evidence spans; claim-only fields remain null on passages and detail does not change catalog rows. Never put `canonical_paraphrase` in quotation marks or claim it is verbatim; follow the timestamped source when exact wording or tone matters. Empty-query behavior and the complete workflow are in `references/report-patterns/media-intelligence.md`. |
 | `search_news` (`query?`, `tickers?`, `topic?`, `sources?`, `start_date?`, `end_date?`, `sort?`, `limit?`) | Search FactIQ's curated business-news feed — public RSS headlines and summaries from Bloomberg, the Financial Times, and the Wall Street Journal, plus India-macro (Zerodha Daily Brief, ET HealthWorld) and global-health sources (WHO, ECDC, CDC, STAT News, KFF), aggregated and processed by FactIQ so each article carries the listed companies it names (`{symbol, exchange, country}`) and an `analysis` block: searchable keywords, a geography, and an `angle` — one sentence on why the story matters to an investor. Company stories get analysis too, not just macro ones; only content with no business read at all (sports, lifestyle, celebrity) comes back with `analysis: null`. Pivot from a story into data: company stories → `get_market_data` / `search_earnings_transcripts` / `search_company_filings`; macro stories → `search_series` / `run_sql`. Results are headline + short publisher summary + link out, never full articles. `query` is lexical full-text over headline+summary — start with short concrete stems (`"obesity drug"`, `"rate cut"`); if a multi-word query matches nothing in full, the tool automatically retries matching ANY of the words with rare words ranked first, flagged as `meta.query_mode: "any_term"`, so one query attempt is usually enough. `tickers` matches share classes and cross-listings automatically (GOOG also finds GOOGL-tagged articles, TSM its Taiwan listing) — pass whichever symbol you know; most macro stories name no listed company, so zero ticker matches is a normal answer. `topic` is one of markets / economics / companies / technology / politics / world / energy / health / india / opinion — combined with a `query` it is a ranking preference (matching sections rank first, but strong matches from other sections still return, since stories often run outside their obvious feed); without a query it filters to the topic's feeds. `sort` is `"latest"` (default) or `"relevance"` (needs a query); `limit` 1–50 (default 20). Coverage is recent news (most feeds start late 2025), and the feed is continuously being expanded and improved — treat it as a current-events lens, not an archive. |
 | `get_style_guides` (`guides`) | FactIQ house-style guides (`"chart"`, `"report"`, `"sql"`, `"earnings"`, or `"all"`). Use these for current style and sourcing rules. Fetch `"earnings"` before writing from `search_earnings_transcripts`. |
+| `publish_html_report` (`question`, `html`, `data_assets`, `model?`) | Writable clients only. Publish an unassembled bespoke HTML template plus `{key, ref_id}` mappings from prior tools' `_factiq_data_ref.id` values. Returns `/share/{share_id}`; never put result rows in the HTML or publish arguments. |
+
+Eligible data-tool results carry a short-lived `_factiq_data_ref`. Preserve it
+when saving the exact result; it is the only value retransmitted when a bespoke
+HTML report is published.
 
 Every row-returning tool (`run_sql`, `get_series`, `search_company_filings`,
 `search_earnings_transcripts`, `search_media_appearances`) returns **at most 50
@@ -375,7 +382,10 @@ local visualizations**). Local-only; never calls the API.
    the findings, local JSON path, and terminal previews. Bespoke-viz mode: save
    each fetched result with `build_viz.py save`, author an HTML file, assemble
    it, render screenshots, inspect and fix it, then give the user the local HTML
-   and PNG paths.
+   and PNG paths. If the user requested a hosted FactIQ share, follow
+   `references/output/publish-html-report.md`: preview with exact locally saved
+   JSON, publish the unassembled HTML with data references, and return the MCP
+   tool's `share_url`.
 
 ## Subagent orchestration
 
@@ -620,6 +630,12 @@ look → fix**:
    explain that the HTML was not screenshot-verified.
 4. Hand the user the local file path; offer `--open` to open it in a browser.
 
+For a FactIQ-hosted result, do not stop at the assembled local file. Read
+`references/output/publish-html-report.md` and use its exact flow: retain each
+source call's `_factiq_data_ref.id`, locally preview against transcript-saved
+JSON, call `publish_html_report` with the unassembled HTML plus key/reference
+mappings, and return the resulting FactIQ share URL.
+
 If the viz will instead be published as a **claude.ai Artifact** that calls
 FactIQ live from the page (`window.claude.mcp`), read
 `references/output/viz-guide.md` (**Publishing as a claude.ai Artifact with
@@ -706,6 +722,8 @@ payload from the transcript so you never retype the rows.
 - `viz-guide.md` — bespoke local HTML visualizations with `build_viz.py`: the
   assemble/render loop, the `DATA` contract, technique selection
   (ECharts/D3/Canvas/WebGL), a legibility checklist, starter recipes.
+- `publish-html-report.md` — publish bespoke HTML to FactIQ with immutable
+  prior-tool-result references, including local preview and sandbox behavior.
 
 **`references/report-patterns/`** — how to think about broad analytical
 questions. Start at `report-patterns/interview-step.md` when the request is

--- a/tests/test_publish_html_report_docs.py
+++ b/tests/test_publish_html_report_docs.py
@@ -1,0 +1,59 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class PublishHtmlReportDocsTests(unittest.TestCase):
+    def test_reuses_exact_result_without_rows_in_arguments(self):
+        prior_result = {
+            "columns": ["period", "value"],
+            "results": [["2026-01", "UNIQUE_ROW_11428031"]],
+            "_factiq_data_ref": {
+                "id": "ref-exact-result",
+                "expires_at": "2026-08-23T12:00:00+00:00",
+            },
+        }
+        exact_bytes = json.dumps(
+            prior_result, ensure_ascii=False, separators=(",", ":")
+        ).encode()
+        with tempfile.TemporaryDirectory() as directory:
+            saved = Path(directory) / "result.json"
+            saved.write_bytes(exact_bytes)
+            self.assertEqual(saved.read_bytes(), exact_bytes)
+
+        html = "<html><script>factiqData('jobs')</script></html>"
+        publish_arguments = {
+            "question": "Labor report",
+            "html": html,
+            "data_assets": [{"key": "jobs", "ref_id": "ref-exact-result"}],
+        }
+        encoded_arguments = json.dumps(publish_arguments)
+        self.assertNotIn("UNIQUE_ROW_11428031", encoded_arguments)
+        self.assertNotIn("results", publish_arguments)
+        self.assertEqual(
+            publish_arguments["data_assets"],
+            [{"key": "jobs", "ref_id": prior_result["_factiq_data_ref"]["id"]}],
+        )
+
+    def test_documents_complete_publish_contract(self):
+        skill = (ROOT / "skills/factiq/SKILL.md").read_text(encoding="utf-8")
+        guide = (ROOT / "references/output/publish-html-report.md").read_text(
+            encoding="utf-8"
+        )
+        shell = (ROOT / "assets/viz-shell.html").read_text(encoding="utf-8")
+        combined = skill + guide
+        for phrase in (
+            "publish_html_report",
+            "_factiq_data_ref",
+            "build_viz.py\" save",
+            "unassembled template",
+            "share_url",
+            "./data/",
+        ):
+            self.assertIn(phrase, combined)
+        self.assertIn("async function factiqData(key)", shell)
+        self.assertIn("sandboxed iframe", guide)

--- a/tests/test_retired_publishing_tools.py
+++ b/tests/test_retired_publishing_tools.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -19,7 +20,11 @@ def test_public_plugin_does_not_reference_retired_publishing_tools():
     offenders = {}
     for path in paths:
         text = path.read_text(encoding="utf-8")
-        found = sorted(name for name in RETIRED_NAMES if name in text)
+        found = sorted(
+            name
+            for name in RETIRED_NAMES
+            if re.search(rf"(?<![A-Za-z0-9_]){re.escape(name)}(?![A-Za-z0-9_])", text)
+        )
         if found:
             offenders[str(path.relative_to(ROOT))] = found
 
@@ -27,4 +32,3 @@ def test_public_plugin_does_not_reference_retired_publishing_tools():
         "Public plugin files still reference retired FactIQ publishing tools: "
         f"{offenders}"
     )
-


### PR DESCRIPTION
## Slack request

[Open the original Slack request](https://defog-ai.slack.com/archives/C0BQM5EN5CM/p1787417097241939)

<pre>hey, i’d like a feature where the factiq-plugin can publish an entire report to factiq via the MCP server. basically where it can upload an entire bespoke html file, and have that html file then be rendered on the worlddb-ui site

this should ideally be done in a way where raw data from tool outputs is saved as JSON and referenced, instead of being outputted token by token

think hard about how to do this. i believe this will involves PRs in each of the factiq-plugin, worlddb, and worlddb-ui repos</pre>

## Acceptance criteria

- Writable MCP clients discover and invoke `publish_html_report`; configured read-only connectors cannot.
- Publishing returns a canonical `/share/{share_id}` URL.
- Prior MCP results are stored byte-for-byte and reused through multiple `{key, ref_id}` mappings without rows in HTML or publish arguments.
- Missing, expired, cross-user, oversized, and duplicate references are rejected before public state creation.
- HTML, asset-count, per-asset, and total-byte limits are enforced atomically.
- Public HTML and report-scoped JSON endpoints preserve bytes and return correct content types.
- Public metadata distinguishes `bespoke_html` from existing `structured` reports.
- worlddb-ui provides responsive sandboxed rendering with loading and failure states.
- Hostile browser coverage verifies cookie/storage, parent-DOM, and top-navigation isolation while allowing report JSON access.
- Forking copies bespoke HTML and every JSON asset; existing structured report publishing and rendering remain covered.
- MCP instructions, retired-tool guidance, plugin documentation, and tests agree on `publish_html_report` and its payload.
- The plugin documents exact transcript saving, local rendering against data keys, reference-only publication, and returning the FactIQ share URL.

## Change

Implemented coordinated publishing across worlddb, worlddb-ui, and factiq-plugin. Writable MCP clients can publish sandboxed HTML reports backed by immutable references to exact prior tool results. Focused backend tests, 462 UI tests, Chromium acceptance coverage, and 58 plugin tests passed.

## Before and after

### Same acceptance input

- **Before (`08143cf66570cab06da8f02b7b6b0d4ac3ecef06`):** `python3 -m unittest discover -s tests -p test_publish_html_report_docs.py` returned non-zero when the candidate's regression test was applied to the unchanged base.
- **After (candidate):** the same `python3 -m unittest discover -s tests -p test_publish_html_report_docs.py` input passed.

### Changed surfaces

- `README.md`
- `assets/viz-shell.html`
- `commands/ask.md`
- `references/output/publish-html-report.md`
- `references/output/viz-guide.md`
- `skills/factiq/SKILL.md`
- `tests/test_publish_html_report_docs.py`
- `tests/test_retired_publishing_tools.py`

### Verified candidate behavior

- Verify exact-result saving, reference-only publish arguments, and complete synchronized workflow documentation.
- Compile the changed plugin tests.

## Verification

The generated acceptance test failed on the base and passed with this change.

- `python3 -m unittest discover -s tests -p test_publish_html_report_docs.py` — Verify exact-result saving, reference-only publish arguments, and complete synchronized workflow documentation.
- `python3 -m py_compile tests/test_publish_html_report_docs.py tests/test_retired_publishing_tools.py` — Compile the changed plugin tests.

The host verified this repository from base `08143cf66570cab06da8f02b7b6b0d4ac3ecef06` and an independent read-only Codex review approved the coordinated diff.

## Review notes

- Non-blocking: `assets/viz-shell.html` now compares against the literal `__FACTIQ_DATA__`, while `scripts/build_viz.py assemble` replaces every occurrence of that marker. Assembly therefore produces invalid JavaScript such as `factiqDataText === "{"jobs":...}"`, breaking the documented local-preview workflow. Restrict replacement to the data script or avoid embedding the marker literally, and add an assemble/render regression test.
- Non-blocking: `with_report_data_reference` stores expiring rows in `mcp_result_references`, but no cleanup removes expired references. Because every eligible MCP data call can add up to 200 KB, a scheduled retention cleanup should be added to prevent indefinite database growth.
- Non-blocking: the publishing guide says `build_viz.py save` copies transcript bytes exactly, but the helper parses and reserializes JSON with `json.loads`/`json.dump`. Values are preserved without model retranscription, and backend publication copies its stored bytes exactly, but the documentation and test should avoid claiming transcript-level byte identity.

## Coordinated pull requests

- `worlddb`: https://github.com/defog-ai/worlddb/pull/1362
- `worlddb-ui`: https://github.com/defog-ai/worlddb-ui/pull/1035

## Safety

- Codex had no GitHub, Slack, SSH, production-write, billing, or signing credentials.
- Production database access inside the agent was read-only.
- Publication was performed by the trusted host after verification.

Generated autonomously by the FactIQ Slack worker.
