### PR TITLE
[DEF-1474] Prepare plugin for Claude directory submission

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,9 @@
 {
   "name": "factiq",
+  "description": "FactIQ plugins for sourced economic, financial, company, market, news, and satellite-data analysis.",
   "owner": {
-    "name": "Defog"
+    "name": "Defog",
+    "url": "https://defog.ai"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,8 +2,8 @@
   "name": "factiq",
   "description": "FactIQ plugins for sourced economic, financial, company, market, news, and satellite-data analysis.",
   "owner": {
-    "name": "Defog",
-    "url": "https://defog.ai"
+    "name": "FactIQ",
+    "url": "https://www.factiq.com"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,21 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, earnings-call transcripts, executive media appearances, a curated business-news feed, and satellite-derived data (nighttime lights, shipping and port activity, reservoir levels, crop fires and wildfires with mappable footprints, NO2/SO2/CO activity, smoke and dust aerosol, monsoon rainfall) — return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
-  "version": "0.27.2",
+  "version": "0.28.0",
   "author": {
-    "name": "Defog"
+    "name": "Defog",
+    "url": "https://defog.ai"
   },
+  "homepage": "https://www.factiq.com/claude",
+  "repository": "https://github.com/defog-ai/factiq-plugin",
+  "license": "MIT",
+  "keywords": [
+    "factiq",
+    "economic-data",
+    "financial-data",
+    "market-data",
+    "mcp"
+  ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, earnings-call transcripts, executive media appearances, a curated business-news feed, and satellite-derived data (nighttime lights, shipping and port activity, reservoir levels, crop fires and wildfires with mappable footprints, NO2/SO2/CO activity, smoke and dust aerosol, monsoon rainfall) — return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
   "version": "0.28.0",
   "author": {
-    "name": "Defog",
-    "url": "https://defog.ai"
+    "name": "FactIQ",
+    "url": "https://www.factiq.com"
   },
   "homepage": "https://www.factiq.com/claude",
   "repository": "https://github.com/defog-ai/factiq-plugin",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,12 +1,14 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real FactIQ data — official data, markets, earnings calls, executive media appearances, and satellite-derived signals including crop fires and wildfires — then return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
-  "version": "0.20.2",
+  "version": "0.28.0",
   "author": {
-    "name": "Defog"
+    "name": "Defog",
+    "url": "https://defog.ai"
   },
   "homepage": "https://github.com/defog-ai/factiq-plugin",
   "repository": "https://github.com/defog-ai/factiq-plugin",
+  "license": "MIT",
   "keywords": [
     "factiq",
     "economic-data",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -3,8 +3,8 @@
   "description": "Answer economic and financial data questions with real FactIQ data — official data, markets, earnings calls, executive media appearances, and satellite-derived signals including crop fires and wildfires — then return sourced answers, terminal previews, report JSON, or bespoke local HTML visualizations.",
   "version": "0.28.0",
   "author": {
-    "name": "Defog",
-    "url": "https://defog.ai"
+    "name": "FactIQ",
+    "url": "https://www.factiq.com"
   },
   "homepage": "https://github.com/defog-ai/factiq-plugin",
   "repository": "https://github.com/defog-ai/factiq-plugin",
@@ -22,7 +22,7 @@
     "displayName": "FactIQ",
     "shortDescription": "Economic and financial data analysis",
     "longDescription": "Use FactIQ for catalog search, read-only SQL, market data, earnings-transcript search, deterministic executive-media search, satellite signals, terminal previews, report JSON, and bespoke local HTML visualizations.",
-    "developerName": "Defog",
+    "developerName": "FactIQ",
     "category": "Finance",
     "capabilities": [
       "Interactive",

--- a/README.md
+++ b/README.md
@@ -255,7 +255,10 @@ Where the behavior lives — the files contributors will touch:
 - `scripts/build_viz.py` — local-only tool that assembles fetched data into a
   self-contained HTML viz and screenshots it headless for iteration. It never
   installs Playwright or Chromium unless `--install-deps` is explicitly
-  passed; usage in [`references/output/viz-guide.md`](references/output/viz-guide.md)
+  passed. On the first approved install it creates the dedicated
+  `~/.factiq/viz-venv`, installs the pinned Playwright package there, and
+  downloads Playwright's matching Chromium build; usage in
+  [`references/output/viz-guide.md`](references/output/viz-guide.md)
 - `assets/viz-shell.html` — starting-point shell for bespoke visualizations
 
 Plugin plumbing — you shouldn't need to touch these:

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,44 @@
+# Connect FactIQ
+
+FactIQ uses the bundled `factiq` remote MCP server and FactIQ OAuth. Do not ask
+the user for an API key, access token, or password. The user completes sign-in
+in FactIQ's browser flow.
+
+## Claude Code
+
+1. If the plugin was installed in the current session, ask the user to run
+   `/reload-plugins` so Claude Code loads the bundled MCP configuration.
+2. Ask the user to run `/mcp` and select `factiq`.
+3. Ask the user to choose **Authenticate** or **Connect**. Claude Code opens the
+   FactIQ sign-in page in a browser.
+4. Wait for the user to finish signing in with email, Google, or a passkey and
+   return to Claude Code.
+5. Run `/mcp` again and confirm that `factiq` is connected. If the server was
+   already connected before a plugin update, reconnect it so Claude refreshes
+   the current tool list.
+
+Claude Code may use a loopback callback with a changing local port. This is
+expected; the user does not need to configure or copy a callback URL.
+
+## Claude web, desktop, and Cowork
+
+Cowork has no terminal, so use only the Claude interface:
+
+1. Open **Customize → Plugins** and select the installed **FactIQ** plugin.
+2. Choose **Connect** for the bundled FactIQ connector.
+3. Complete the FactIQ browser sign-in with email, Google, or a passkey, then
+   return to Claude.
+4. Confirm that FactIQ shows as connected. If Claude reports stale or missing
+   tools after an update, disconnect and reconnect FactIQ to refresh its tool
+   list.
+
+## Verify the connection
+
+Ask: **Use FactIQ to list the available data schemas.** A working connection
+calls `get_data_catalog` and returns the live FactIQ catalog. Do not use another
+data source for this check.
+
+If authentication is stuck, sign in to [FactIQ](https://www.factiq.com) in the
+same browser and retry **Connect**. Setup instructions and current plan support
+are maintained at [factiq.com/claude](https://www.factiq.com/claude) and
+[factiq.com/claude-code](https://www.factiq.com/claude-code).

--- a/scripts/build_viz.py
+++ b/scripts/build_viz.py
@@ -397,6 +397,7 @@ def cmd_assemble(args: argparse.Namespace) -> None:
 
 
 VENV_DIR = os.path.expanduser("~/.factiq/viz-venv")
+PLAYWRIGHT_PACKAGE = "playwright==1.62.0"
 
 
 def _venv_python(venv_dir: str) -> str:
@@ -484,9 +485,17 @@ def _ensure_render_env(install_deps: bool):
             flush=True,
         )
         cmd = (
-            [uv, "pip", "install", "--python", venv_py, "--quiet", "playwright"]
+            [
+                uv,
+                "pip",
+                "install",
+                "--python",
+                venv_py,
+                "--quiet",
+                PLAYWRIGHT_PACKAGE,
+            ]
             if uv
-            else [venv_py, "-m", "pip", "install", "--quiet", "playwright"]
+            else [venv_py, "-m", "pip", "install", "--quiet", PLAYWRIGHT_PACKAGE]
         )
         try:
             subprocess.run(cmd, check=True)

--- a/tests/test_build_viz_install_opt_in.py
+++ b/tests/test_build_viz_install_opt_in.py
@@ -41,6 +41,12 @@ class DocumentationContractTests(unittest.TestCase):
 
 
 class RenderDependencyOptInTests(unittest.TestCase):
+    def test_playwright_install_is_pinned(self):
+        self.assertRegex(
+            build_viz.PLAYWRIGHT_PACKAGE,
+            r"^playwright==\d+\.\d+\.\d+$",
+        )
+
     def test_install_deps_is_off_by_default_and_requires_a_flag(self):
         parser = build_viz.build_parser()
 
@@ -92,6 +98,35 @@ class RenderDependencyOptInTests(unittest.TestCase):
             build_viz._ensure_render_env(install_deps=False)
 
         execve.assert_called_once()
+
+    def test_approved_install_uses_the_pinned_playwright_package(self):
+        real_import = __import__
+
+        def import_without_playwright(name, *args, **kwargs):
+            if name == "playwright.sync_api":
+                raise ImportError("not installed")
+            return real_import(name, *args, **kwargs)
+
+        def fake_run(command, **_kwargs):
+            if command[-2:] == ["-c", "import playwright.sync_api"]:
+                return mock.Mock(returncode=1)
+            return mock.Mock(returncode=0)
+
+        with (
+            mock.patch("builtins.__import__", side_effect=import_without_playwright),
+            mock.patch.object(build_viz.os.path, "exists", return_value=False),
+            mock.patch.object(build_viz.shutil, "which", return_value="/usr/bin/uv"),
+            mock.patch.object(build_viz.subprocess, "run", side_effect=fake_run) as run,
+            mock.patch.object(build_viz.os, "execve"),
+        ):
+            build_viz._ensure_render_env(install_deps=True)
+
+        install_command = next(
+            call.args[0]
+            for call in run.call_args_list
+            if "install" in call.args[0]
+        )
+        self.assertEqual(install_command[-1], build_viz.PLAYWRIGHT_PACKAGE)
 
     def test_missing_chromium_is_not_installed_without_opt_in(self):
         chromium = mock.Mock()

--- a/tests/test_directory_submission_readiness.py
+++ b/tests/test_directory_submission_readiness.py
@@ -7,9 +7,12 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class DirectorySubmissionReadinessTests(unittest.TestCase):
-    def test_claude_manifests_have_complete_publisher_metadata(self):
+    def test_manifests_have_complete_factiq_publisher_metadata(self):
         plugin = json.loads(
             (ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+        codex = json.loads(
+            (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         marketplace = json.loads(
             (ROOT / ".claude-plugin" / "marketplace.json").read_text(
@@ -17,14 +20,20 @@ class DirectorySubmissionReadinessTests(unittest.TestCase):
             )
         )
 
-        self.assertEqual(plugin["author"]["url"], "https://defog.ai")
+        expected_publisher = {
+            "name": "FactIQ",
+            "url": "https://www.factiq.com",
+        }
+        self.assertEqual(plugin["author"], expected_publisher)
+        self.assertEqual(codex["author"], expected_publisher)
+        self.assertEqual(codex["interface"]["developerName"], "FactIQ")
         self.assertEqual(
             plugin["repository"], "https://github.com/defog-ai/factiq-plugin"
         )
         self.assertEqual(plugin["license"], "MIT")
         self.assertTrue(plugin["keywords"])
         self.assertTrue(marketplace["description"])
-        self.assertEqual(marketplace["owner"]["url"], "https://defog.ai")
+        self.assertEqual(marketplace["owner"], expected_publisher)
 
     def test_claude_and_codex_versions_stay_in_sync(self):
         claude = json.loads(

--- a/tests/test_directory_submission_readiness.py
+++ b/tests/test_directory_submission_readiness.py
@@ -1,0 +1,52 @@
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class DirectorySubmissionReadinessTests(unittest.TestCase):
+    def test_claude_manifests_have_complete_publisher_metadata(self):
+        plugin = json.loads(
+            (ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+        marketplace = json.loads(
+            (ROOT / ".claude-plugin" / "marketplace.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+        self.assertEqual(plugin["author"]["url"], "https://defog.ai")
+        self.assertEqual(
+            plugin["repository"], "https://github.com/defog-ai/factiq-plugin"
+        )
+        self.assertEqual(plugin["license"], "MIT")
+        self.assertTrue(plugin["keywords"])
+        self.assertTrue(marketplace["description"])
+        self.assertEqual(marketplace["owner"]["url"], "https://defog.ai")
+
+    def test_claude_and_codex_versions_stay_in_sync(self):
+        claude = json.loads(
+            (ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+        codex = json.loads(
+            (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(claude["version"], codex["version"])
+
+    def test_setup_covers_terminal_and_terminal_free_auth(self):
+        setup = (ROOT / "SETUP.md").read_text(encoding="utf-8")
+        for expected in (
+            "Claude Code",
+            "/mcp",
+            "Cowork has no terminal",
+            "Customize → Plugins",
+            "get_data_catalog",
+            "Do not ask",
+        ):
+            self.assertIn(expected, setup)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- complete the Claude marketplace and plugin publisher metadata and synchronize the Claude/Codex manifests at version 0.28.0
- add root `SETUP.md` guidance for Claude Code `/mcp` authentication and the terminal-free Claude/Cowork connection flow
- pin the opt-in visualization environment to Playwright 1.62.0 and document its dedicated venv/Chromium first-run installation
- add submission-readiness tests for metadata, version synchronization, setup coverage, and the dependency pin

## Before and after

- Before: `claude plugin validate .` passed with a warning because the marketplace had no description.
- After: it passes with zero warnings.
- Before: the plugin had no root setup skill, so Claude had no surface-specific MCP authentication instructions.
- After: Claude Code and Cowork each have explicit connection, refresh, verification, and troubleshooting steps without requesting secrets.
- Before: `--install-deps` installed whatever Playwright release was current at first run.
- After: it installs `playwright==1.62.0` into `~/.factiq/viz-venv`, keeping the downloaded Chromium build reproducible.

## Validation

- 60 unit tests passed
- `claude plugin validate .` passed with zero warnings
- Codex plugin validator passed
- `git diff --check`

## Coordinated backend change

- https://github.com/defog-ai/worlddb/pull/1368

Linear: DEF-1474
