### PR TITLE
Teach calendar-date YoY and the missing_periods signal

### DIFF
--- a/references/data/sql-guide.md
+++ b/references/data/sql-guide.md
@@ -312,6 +312,42 @@ them transparently (returns columns + results like a timeseries) — prefer it.
 For direct SQL: `row_data->>'column_name'` extracts text; cast with `::numeric`
 for math.
 
+## Period-over-period changes: join on the date, never on the row
+
+`LAG(value, 12) OVER (ORDER BY time)` steps back twelve **rows**, not twelve
+**months**. Government series skip periods (BLS published no October 2025 CPI
+or unemployment rate), and from the first hole on a row offset compares the
+wrong periods while still returning plausible numbers. The server rejects a
+LAG/LEAD statement whose series has a hole inside the statement's window and
+tells you which period is missing. Write the comparison as an exact-date
+self-join instead:
+
+```sql
+WITH cur AS (
+  SELECT series_id, time, value FROM data_points
+  WHERE series_id IN ('CUUR0000SA0') AND time >= '2019-01-01'
+)
+SELECT c.series_id, c.time, 100 * (c.value / p.value - 1) AS yoy_pct
+FROM cur c
+JOIN cur p ON p.series_id = c.series_id
+          AND p.time = c.time - interval '1 year'   -- '1 month' for MoM, '3 months' for QoQ
+ORDER BY c.series_id, c.time
+```
+
+Periods with no prior-year observation drop out instead of shifting. The same
+rule applies to local computation: `series.shift(12)` on a pandas Series is a
+row offset too; shift by a date offset or reindex to a complete monthly
+calendar first.
+
+Every `get_series` and `run_sql` result that touches a monthly, quarterly, or
+annual series with a hole carries `missing_periods` (per series id, with the
+period labels) and a `missing_periods_note`. When it is present: say which
+periods are missing in the answer, and label any aggregate that spans one as
+partial (a Q4 2025 average built from November and December is a two-month
+average, not a quarter). If you need a row per calendar period regardless,
+build the calendar with `generate_series` and LEFT JOIN the observations onto
+it; a row offset over that scaffold is aligned, and the server only warns.
+
 ## Efficiency
 
 - Most questions need 2–4 data calls. Batch independent fetches in one turn.

--- a/references/output/chart-spec.md
+++ b/references/output/chart-spec.md
@@ -143,8 +143,8 @@ SQL, computations — ending in a single `output` node:
     {
       "id": "calc", "type": "code", "inputs": ["sql1"],
       "title": "Computed YoY change",
-      "summary": "12-month difference on the monthly rate",
-      "detail": "", "code": "yoy = rate - rate.shift(12)", "code_language": "python"
+      "summary": "12-month difference on the monthly rate, matched by calendar month (a row shift misaligns after a missing month)",
+      "detail": "", "code": "yoy = rate - rate.reindex(rate.index - pd.DateOffset(years=1)).values", "code_language": "python"
     },
     {
       "id": "out", "type": "output", "inputs": ["calc"],

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -326,11 +326,20 @@ previews.
    default categorically to monthly or yearly rows.
 4. **Compute deterministically.** For YoY/YTD growth, shares, rebasing, or
    merging compatible results, save the fetched `columns` and `results` as a
-   local FactIQ payload and use `series_math.py`. Never inspect Claude/Codex
-   transcripts or session directories to recover tool results. For other
-   metrics such as per-capita values or custom ratios, write a small local
-   Python calculation on the fetched values. There is no server-side code
-   interpreter in this loop.
+   local FactIQ payload and use `series_math.py`. It matches each period to
+   the same month or quarter of the prior year by calendar date, which is why
+   it beats `LAG(value, 12) OVER (ORDER BY time)` in SQL or pandas
+   `.shift(12)`: those are row offsets, and one missing observation (BLS
+   published no October 2025 CPI or unemployment rate) makes every later row
+   compare the wrong months while still looking plausible. `run_sql` rejects
+   such a statement over a series with a hole; if you must do it in SQL, join
+   on `p.time = c.time - interval '1 year'`. When a result carries
+   `missing_periods`, name those periods in the answer and mark any aggregate
+   that spans one as partial (a Q4 built from November and December is a
+   two-month average). Never inspect Claude/Codex transcripts or session
+   directories to recover tool results. For other metrics such as per-capita
+   values or custom ratios, write a small local Python calculation on the
+   fetched values. There is no server-side code interpreter in this loop.
 5. **Recent market data.** The DB lags for very recent market/price data — use
    `get_market_data` for current quotes, commodities, and FX. For what the
    news is saying about a company, sector, or economy right now, use
@@ -409,7 +418,9 @@ Steps:
 1. search_datasets / describe_dataset / search_series to find the right series.
 2. Fetch data with get_series or run_sql. Aggregate in SQL to stay under the
    50-row cap.
-3. Compute derived metrics (YoY, ratios, indices) yourself.
+3. Compute derived metrics (YoY, ratios, indices) yourself: YoY with
+   `series_math.py` or an exact-date join, never a row offset. Carry any
+   `missing_periods` from the results into your findings.
 4. Return your findings as a structured block:
 
 FINDINGS:


### PR DESCRIPTION
The plugin guides now say to compute period-over-period changes by calendar date, never by row offset, and to carry the server's new `missing_periods` signal into answers. Companion to the worlddb change for DEF-1555, where `run_sql` rejects a LAG/LEAD statement over a series with a missing period and attaches `missing_periods` to results.

## Why

`LAG(value, 12) OVER (ORDER BY time)` and pandas `.shift(12)` step back twelve rows, not twelve months. BLS published no October 2025 CPI or unemployment rate, so from November 2025 on those comparisons used the wrong months while still returning plausible values (the P1 directory case: Q1 2026 CPI YoY 3.14% by row offset versus 2.69% by exact date). `series_math.py yoy` already matches by calendar period, so the guidance now says why it is preferred and what to do when SQL is unavoidable.

## What changed

- `references/data/sql-guide.md`: new section "Period-over-period changes: join on the date, never on the row" with the exact-date self-join, the partial-aggregate rule (a Q4 built from November and December is a two-month average), and the `generate_series` scaffold escape hatch. Mirrors the server guide.
- `references/output/chart-spec.md`: the example YoY step no longer uses `rate.shift(12)`; it reindexes by a one-year date offset.
- `skills/factiq/SKILL.md`: step 4 explains that `series_math.py` matches by calendar period and forbids row offsets; the sub-agent steps tell it to carry `missing_periods` into findings.

## Before / after

Before, `chart-spec.md` taught:

```python
yoy = rate - rate.shift(12)
```

After:

```python
yoy = rate - rate.reindex(rate.index - pd.DateOffset(years=1)).values
```

Plugin tests: 55 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
