### PR TITLE
Compute year-over-year by calendar date, never by row offset

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real data from FactIQ — official statistics, market data, earnings-call transcripts, executive media appearances, a curated business-news feed, and satellite-derived data (nighttime lights, shipping and port activity, reservoir levels, crop fires and wildfires with mappable footprints, NO2/SO2/CO activity, smoke and dust aerosol, monsoon rainfall) — return sourced answers, terminal previews, or report JSON.",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "author": {
     "name": "FactIQ",
     "url": "https://www.factiq.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "factiq",
   "description": "Answer economic and financial data questions with real FactIQ data — official data, markets, earnings calls, executive media appearances, and satellite-derived signals including crop fires and wildfires — then return sourced answers, terminal previews, or report JSON.",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "author": {
     "name": "FactIQ",
     "url": "https://www.factiq.com"

--- a/references/data/sql-guide.md
+++ b/references/data/sql-guide.md
@@ -32,6 +32,10 @@ The `get_data_catalog` tool returns the full DDL.
   `'annual'`, `'weekly'`, `'semiannual'`. `frequency = 'Monthly'` matches
   nothing.
 - **`dataset_code` is lowercase** — use ILIKE or lowercase literals.
+- **`data_points.time` is the period start**: a monthly observation is stored
+  on the first of its month, a quarterly one on the first day of its quarter.
+  `time - interval '1 year'` and `time - interval '1 month'` therefore land
+  exactly on the prior period's stored date.
 - The server rewrites `series_title` to
   `COALESCE(human_friendly_title, series_title)` automatically, normalizes
   frequency filters, and turns `data_points.series_id` pattern filters into
@@ -125,6 +129,64 @@ fragment instead:
 
 Never chart a single state/region as if it were the national figure. If you
 can't find the national aggregate, say so rather than substituting.
+
+## Year-over-year on monthly data — never use LAG(value, 12)
+
+A row offset equals a period offset only when every period is present. Series
+have holes: a month the source never published, a quarter outside the
+requested window, a period a WHERE clause removed. After a hole,
+`LAG(value, 12)` compares each month with the month **thirteen** periods back,
+the numbers stay plausible, and nothing errors.
+
+Bad — silently wrong after any gap:
+
+```sql
+SELECT time, 100 * (value / LAG(value, 12) OVER (ORDER BY time) - 1) AS yoy_pct
+FROM data_points
+WHERE series_id = 'CUUR0000SA0' AND time >= '2019-01-01'
+ORDER BY time
+```
+
+Good — join on the exact date, so a missing prior period gives no row (or a
+null with a LEFT JOIN) instead of a wrong number:
+
+```sql
+SELECT cur.time,
+       100 * (cur.value / prior.value - 1) AS yoy_pct
+FROM data_points cur
+JOIN data_points prior
+  ON prior.series_id = cur.series_id
+ AND prior.time = cur.time - interval '1 year'
+WHERE cur.series_id = 'CUUR0000SA0' AND cur.time >= '2020-01-01'
+ORDER BY cur.time
+```
+
+Also good — build a complete date spine first; on a spine every period has a
+row, so a row offset is a period offset and LAG is correct:
+
+```sql
+WITH spine AS (
+  SELECT generate_series('2019-01-01'::timestamp, '2026-06-01', interval '1 month') AS time
+),
+cpi AS (
+  SELECT s.time, d.value
+  FROM spine s
+  LEFT JOIN data_points d ON d.time = s.time AND d.series_id = 'CUUR0000SA0'
+)
+SELECT time, value, 100 * (value / LAG(value, 12) OVER (ORDER BY time) - 1) AS yoy_pct
+FROM cpi WHERE time >= '2020-01-01' ORDER BY time
+```
+
+For one series, `get_series` with `transform="yoy_pct"` (or `"yoy_diff"` for a
+rate) does the date-matched calculation on the server. For several series or
+a merged table, `scripts/series_math.py yoy` matches on the calendar period
+too.
+
+The result's `coverage_note` and `missing_periods` name the holes in the rows
+you received, and `run_sql` says so when the statement itself uses a fixed
+LAG/LEAD offset over time. Act on them: state the missing period(s) in the
+answer, leave the month blank in a chart rather than interpolating, and label
+an aggregate that spans a hole as partial ("Q4 2025 average of two months").
 
 ## HS trade datasets
 
@@ -301,6 +363,10 @@ WHERE series_id IN ('LNS14000000', 'LNS11300000')
 GROUP BY time
 ORDER BY time
 ```
+
+A period with no row in `data_points` is absent from the pivot, not a null
+cell: the time axis skips it. Read the result's `coverage_note` before
+computing changes across rows.
 
 ## Tabular data
 

--- a/references/data/sql-guide.md
+++ b/references/data/sql-guide.md
@@ -34,9 +34,13 @@ The `get_data_catalog` tool returns the full DDL.
 - **`dataset_code` is lowercase** — use ILIKE or lowercase literals.
 - **Match periods on the calendar month, never on the exact date.** The day
   stored inside `data_points.time` varies by source: most store the first day
-  of the period, some store the last day (quarter-end or fiscal-year-end
-  dates). Join and compare on `date_trunc('month', time)` (or
-  `date_trunc('quarter', time)` for quarterly series):
+  of the period, but `frb`, `rbi`, `fhfa` and `treasury` store monthly values
+  on the last day of the month (`2025-02-28`, `2025-03-31`), and `frb`, `rbi`,
+  `fhfa` and `cbo` store quarters on quarter-end dates. An exact-date join
+  such as `prior.time = cur.time - interval '1 year'` finds nothing for those
+  (February 29 minus one year is February 28). Join and compare on
+  `date_trunc('month', time)` (or `date_trunc('quarter', time)` for quarterly
+  series):
   `date_trunc('month', prior.time) = date_trunc('month', cur.time) - interval '1 year'`.
 - The server rewrites `series_title` to
   `COALESCE(human_friendly_title, series_title)` automatically, normalizes

--- a/references/data/sql-guide.md
+++ b/references/data/sql-guide.md
@@ -32,10 +32,12 @@ The `get_data_catalog` tool returns the full DDL.
   `'annual'`, `'weekly'`, `'semiannual'`. `frequency = 'Monthly'` matches
   nothing.
 - **`dataset_code` is lowercase** — use ILIKE or lowercase literals.
-- **`data_points.time` is the period start**: a monthly observation is stored
-  on the first of its month, a quarterly one on the first day of its quarter.
-  `time - interval '1 year'` and `time - interval '1 month'` therefore land
-  exactly on the prior period's stored date.
+- **Match periods on the calendar month, never on the exact date.** The day
+  stored inside `data_points.time` varies by source: most store the first day
+  of the period, some store the last day (quarter-end or fiscal-year-end
+  dates). Join and compare on `date_trunc('month', time)` (or
+  `date_trunc('quarter', time)` for quarterly series):
+  `date_trunc('month', prior.time) = date_trunc('month', cur.time) - interval '1 year'`.
 - The server rewrites `series_title` to
   `COALESCE(human_friendly_title, series_title)` automatically, normalizes
   frequency filters, and turns `data_points.series_id` pattern filters into
@@ -147,8 +149,11 @@ WHERE series_id = 'CUUR0000SA0' AND time >= '2019-01-01'
 ORDER BY time
 ```
 
-Good — join on the exact date, so a missing prior period gives no row (or a
-null with a LEFT JOIN) instead of a wrong number:
+Good — join on the calendar month, so a missing prior period gives no row (or
+a null with a LEFT JOIN) instead of a wrong number. Compare
+`date_trunc('month', time)`, not `time` itself: the stored day of the month
+differs between sources (first of the month for most, last day of the period
+for some), and an exact-date join silently finds nothing for those.
 
 ```sql
 SELECT cur.time,
@@ -156,10 +161,13 @@ SELECT cur.time,
 FROM data_points cur
 JOIN data_points prior
   ON prior.series_id = cur.series_id
- AND prior.time = cur.time - interval '1 year'
+ AND date_trunc('month', prior.time) = date_trunc('month', cur.time) - interval '1 year'
 WHERE cur.series_id = 'CUUR0000SA0' AND cur.time >= '2020-01-01'
 ORDER BY cur.time
 ```
+
+For quarterly series use `date_trunc('quarter', ...)` on both sides; for
+month-over-month subtract `interval '1 month'`.
 
 Also good — build a complete date spine first; on a spine every period has a
 row, so a row offset is a period offset and LAG is correct:
@@ -171,7 +179,8 @@ WITH spine AS (
 cpi AS (
   SELECT s.time, d.value
   FROM spine s
-  LEFT JOIN data_points d ON d.time = s.time AND d.series_id = 'CUUR0000SA0'
+  LEFT JOIN data_points d
+    ON date_trunc('month', d.time) = s.time AND d.series_id = 'CUUR0000SA0'
 )
 SELECT time, value, 100 * (value / LAG(value, 12) OVER (ORDER BY time) - 1) AS yoy_pct
 FROM cpi WHERE time >= '2020-01-01' ORDER BY time

--- a/references/data/sql-guide.md
+++ b/references/data/sql-guide.md
@@ -140,8 +140,9 @@ can't find the national aggregate, say so rather than substituting.
 
 A row offset equals a period offset only when every period is present. Series
 have holes: a month the source never published, a quarter outside the
-requested window, a period a WHERE clause removed. After a hole,
-`LAG(value, 12)` compares each month with the month **thirteen** periods back,
+requested window, a period a WHERE clause removed. For the twelve rows after
+a hole, `LAG(value, 12)` compares each month with the month **thirteen**
+periods back (`LEAD(value, 12)` does the same for the twelve rows before it),
 the numbers stay plausible, and nothing errors.
 
 Bad — silently wrong after any gap:

--- a/references/output/chart-spec.md
+++ b/references/output/chart-spec.md
@@ -142,8 +142,8 @@ single `output` node:
     {
       "id": "calc", "type": "code", "inputs": ["sql1"],
       "title": "Computed YoY change",
-      "summary": "12-month difference on the monthly rate",
-      "detail": "", "code": "yoy = rate - rate.shift(12)", "code_language": "python"
+      "summary": "Same month one year earlier, matched by date, never a 12-row shift",
+      "detail": "", "code": "python3 series_math.py yoy --file rates.json --group-col series_id", "code_language": "bash"
     },
     {
       "id": "out", "type": "output", "inputs": ["calc"],

--- a/references/report-patterns/README.md
+++ b/references/report-patterns/README.md
@@ -121,6 +121,11 @@ instantiation takes. The frequent case:
   warehouse lacks a required counter-check (current OMO detail, services
   trade, distributional tax data), say so in the report — a named data gap is
   itself a finding about how confident the synthesis can be.
+- **A missing period is disclosed, not bridged.** When a fetch carries a
+  `coverage_note`, the periods it names are absent from the data: say so in
+  the report, leave them blank in charts, and label an aggregate that spans
+  one as partial. Never estimate the missing value or let a row-offset
+  calculation slide over it.
 - **Measured vs inferred, always labeled.** Thesis and antithesis are fetched
   numbers; the synthesis is interpretation and must be presented as such,
   resting explicitly on the evidence from both passes.

--- a/scripts/series_math.py
+++ b/scripts/series_math.py
@@ -7,7 +7,9 @@ Use this instead of computing growth rates, shares, or unit conversions in
 your own tokens: the script's arithmetic is exact and repeatable.
 
 Subcommands:
-  yoy      year-over-year % change (same month/quarter, previous year)
+  yoy      year-over-year % change (same month/quarter of the previous year,
+           matched by date — a missing period gives a blank, never a shifted
+           comparison; periods with no prior-year value are listed on stderr)
   ytd      calendar year-to-date cumulative total + YoY % vs prior-year YTD
   share    each group's % share of the per-period total (needs --group-col)
   index    rebase each group to 100 at one YYYY, YYYY-Qn, or YYYY-MM period
@@ -296,19 +298,34 @@ def cmd_yoy(args) -> None:
     columns, rows = load_table(args.file)
     groups, _ = split_rows(args, columns, rows)
     out = []
+    without_prior: list[str] = []
     with localcontext() as context:
         context.prec = arithmetic_precision(groups)
         for key, series in sorted(groups.items()):
             prior = {(y, m): v for y, m, _, v in series}
+            first_year = min(y for y, _, _, _ in series)
             for y, m, t, v in series:
                 prev = prior.get((y - 1, m))
                 pct = (v / prev - 1) * 100 if prev not in (None, 0) else None
+                if (y - 1, m) not in prior and y > first_year:
+                    # The first year has no prior by construction; a later
+                    # blank means the prior-year period is missing from the
+                    # payload, which the caller must disclose.
+                    without_prior.append(f"{key}: {t}" if args.group_col else str(t))
                 out.append(
                     ([key] if args.group_col else [])
                     + [t, v, "" if pct is None else round(pct, 4)]
                 )
     header = ([args.group_col] if args.group_col else []) + ["time", "value", "yoy_pct"]
     emit(header, out)
+    if without_prior:
+        print(
+            "note: no prior-year observation for "
+            + ", ".join(without_prior)
+            + " — yoy_pct is blank there; say so in the answer rather than "
+            "interpolating or comparing with a different period",
+            file=sys.stderr,
+        )
 
 
 def cmd_ytd(args) -> None:

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -103,7 +103,7 @@ All FactIQ tools are MCP tools provided by the `factiq` MCP server.
 | `describe_dataset` (`schema`, `dataset_code`) | Full metadata for one dataset: topic, methodology, release dates, base-change notice, dimensions, example series. Call after `search_datasets`. |
 | `search_series` (`schema`, `terms`, `limit?`, `include_compound?`) | Series-level title-substring search within one schema (`terms` is a list — prefer short stems). Includes `COMPOUND::` series. |
 | `run_sql` (`schema`, `sql`, `question?`, `explore?`, `auto_retry?`, `page?`) | Read-only SELECT against one schema. The power tool for joins, pivots, aggregation. `page` works on the `nasa_fires` schema only, where individual rows are the answer; everywhere else, aggregate. |
-| `get_series` (`schema`, `series_id`, `from_year?`, `to_year?`) | Fetch one series — timeseries, tabular, or `COMPOUND::` ids all work. SEC-backed results include `row_sources` keyed by `result_index`, with the supporting filing, accession/form/date, reported-vs-derived status, and a standardized `source_link`. |
+| `get_series` (`schema`, `series_id`, `from_year?`, `to_year?`, `transform?`) | Fetch one series — timeseries, tabular, or `COMPOUND::` ids all work. `transform="yoy_pct"` (percent change) or `"yoy_diff"` (difference, for rates) adds a column with the change versus the same period one year earlier, matched by calendar date; the cell is null where that period is absent. A `coverage_note` with `missing_periods` means the series skips a period — disclose it. SEC-backed results include `row_sources` keyed by `result_index`, with the supporting filing, accession/form/date, reported-vs-derived status, and a standardized `source_link`. |
 | `get_market_data` (`asset`, `data_type?`, `frequency?`, `limit?`) | Provider-neutral quotes, daily/weekly/monthly price history, company and ETF profiles, symbol search, FX, and commodities. `data_type` is `price_history`, `quote`, `company_profile`, `etf_profile`, or `symbol_search`; `limit` is 1–5,000. |
 | `get_geo_data` (`dataset`, `region`, `start_date`, `end_date`, `aggregation?`, `resolution?`, `include_flares?`) | Satellite-derived signals: `fires_viirs` (crop burning/wildfires; every detection since 2012 is held in FactIQ's own database, so calls answer in under a second — `aggregation="seasons"` compares the same calendar window in every year since 2012 in one call, `"grid"` maps the footprint at a cell size you pick with `resolution`, `"points"` returns exact detection coordinates), `no2_tropomi` / `so2_tropomi` / `co_tropomi` (industrial, coal/smelting, and combustion activity), `aerosol_index_tropomi` (smoke/dust/haze), `ndvi_s2` (crop condition) — these five also accept `aggregation="grid"` for a cell-by-cell spatial snapshot — `precip_chirps` (0.05° gauge-calibrated rainfall within 50S-50N), `precip_imerg` (0.1° global rainfall), `temperature_power`, `soil_moisture_power` — aggregated over a country, state (`"India/Punjab"`), or bbox. `resolution` and `include_flares` apply to `fires_viirs` only; gas flares and other permanent industrial heat are excluded unless you ask for them. **Read `references/data/satellite.md` before first use** — it covers windows (50 intervals, 200 for fires; grid/points 92 days, 366 for fires), the `valid_obs_share` rule, and attribution. For fire questions this tool does not cover, query the `nasa_fires` SQL schema (`references/data/schemas.md`). |
 | `search_company_filings` (`company`, `query?`, `concept?`, `search_target?`, `report_type?`, `fiscal_year?`, `fiscal_period?`, `metric_class?`, `segment?`, `date_from?`, `date_to?`, `active_only?`, `format?`, `limit?`) | The central tool for company filings. Deterministic (no model) search over the structured facts and report metadata in one company's filed reports, for every company FactIQ covers: US SEC filers (10-K, 10-Q, 8-K, plus 20-F/40-F/6-K for foreign filers) and companies listed in Germany (annual, half-year, Q1, and Q3 reports, values in EUR — e.g. `company="BAS"` for BASF SE). Use an exact ticker; a share-class sibling (GOOGL for GOOG) resolves to the same filer, a German company resolves by its German ticker, full name, or LEI, and an ambiguous name comes back with `possible_matches`. Start with `search_target="coverage"` to see which report types, periods, and metric classes exist. Then set `concept` to one metric name (`"revenue"`, `"net income"`) to get that concept's values across periods, or use `search_target="metrics"` to list stored concepts and `"facts"` for reported values. `query` is a lexical text search across concept names, source labels, aliases, and segment names; narrow with `metric_class` (`financial`, `ifrs`, `segment`, `geography`, `product`, `kpi`, `apm`, `guidance`), `segment`, `report_type` (`annual`, `quarterly`, `half_year`, `10-K`, `10-Q`), `fiscal_year` + `fiscal_period` (`2025`, `Q3`), or `date_from`/`date_to`. Every result is a tree: company → metric class → concept → series → period. With `format="json"`, filing/fact nodes retain the report URL and add a standardized `source_link`; exact-ticker metrics/facts misses may fall back to standardized statements with no filing evidence. `format="pretty"` returns a rendered text tree instead of JSON. When a company reports the same concept twice in one filing, the second copy is labeled "Reported line 2" — never add it to the first. Results stop at `limit` (max 50) with `truncated: true`; narrow the filters rather than paging. |
@@ -337,6 +337,15 @@ previews.
    metrics such as per-capita values or custom ratios, write a small local
    Python calculation on the fetched values. There is no server-side code
    interpreter in this loop.
+   Year-over-year is the same period one year earlier, **matched by date**,
+   never by row position: for one series use `get_series` with
+   `transform="yoy_pct"` (or `"yoy_diff"` for a rate); for several series or a
+   merged table use `series_math.py yoy`; in SQL join on
+   `prior.time = cur.time - interval '1 year'`, never `LAG(value, 12)` (see the
+   trap in `references/data/sql-guide.md`). When a tool result carries a
+   `coverage_note`, the rows skip the periods in `missing_periods`: name them
+   in the answer, do not interpolate, and label any aggregate that spans them
+   as partial ("Q4 2025 average of two months").
 5. **Recent market data.** The DB lags for very recent market/price data — use
    `get_market_data` for current quotes, commodities, and FX. For what the
    news is saying about a company, sector, or economy right now, use
@@ -413,7 +422,10 @@ Relevant schemas/datasets (from the parent's catalog step): {hints}
 
 Constraints: every tool result is capped at 50 rows, so aggregate in SQL to
 the grain the finding needs; compute derived metrics (YoY, ratios, indices)
-yourself from the fetched values.
+yourself from the fetched values. Year-over-year is the same period one year
+earlier matched by date (get_series with transform="yoy_pct", series_math.py
+yoy, or an exact-date SQL join), never a 12-row offset. Report any
+coverage_note / missing_periods from the tool results in your findings.
 
 Return your findings as a structured block:
 
@@ -576,6 +588,12 @@ which is also all it needs.
 - **Zero rows** — your filter was too narrow. Broaden it yourself (see
   `references/data/sql-guide.md`). `auto_retry=true` opts into a server-side LLM
   reviser, but you can usually revise better and cheaper yourself.
+- **`coverage_note` on a result** — not an error: the rows skip the periods in
+  `missing_periods` (a month the source never published, or one the query
+  window cut off). Any period-over-period figure built with a fixed row
+  offset (`LAG(value, 12)`, `shift(12)`, "the row 12 back") over those rows
+  is wrong from the first gap onward. Recompute by matching dates, name the
+  missing periods in the answer, and label partial aggregates as partial.
 - **SQL timeout** — statements are capped at 30s. Filter on indexed columns
   (`series_id`, `dataset_code`) instead of scanning titles, and never
   pattern-match `series_id` on `data_points` — resolve ids from `series` first

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -340,9 +340,11 @@ previews.
    Year-over-year is the same period one year earlier, **matched by date**,
    never by row position: for one series use `get_series` with
    `transform="yoy_pct"` (or `"yoy_diff"` for a rate); for several series or a
-   merged table use `series_math.py yoy`; in SQL join on
-   `prior.time = cur.time - interval '1 year'`, never `LAG(value, 12)` (see the
-   trap in `references/data/sql-guide.md`). When a tool result carries a
+   merged table use `series_math.py yoy`; in SQL join on the calendar month
+   (`date_trunc('month', prior.time) = date_trunc('month', cur.time) - interval '1 year'`
+   — the stored day of the month varies by source, so never compare exact
+   dates), never `LAG(value, 12)` (see the trap in
+   `references/data/sql-guide.md`). When a tool result carries a
    `coverage_note`, the rows skip the periods in `missing_periods`: name them
    in the answer, do not interpolate, and label any aggregate that spans them
    as partial ("Q4 2025 average of two months").
@@ -424,7 +426,8 @@ Constraints: every tool result is capped at 50 rows, so aggregate in SQL to
 the grain the finding needs; compute derived metrics (YoY, ratios, indices)
 yourself from the fetched values. Year-over-year is the same period one year
 earlier matched by date (get_series with transform="yoy_pct", series_math.py
-yoy, or an exact-date SQL join), never a 12-row offset. Report any
+yoy, or a SQL join on date_trunc('month', time)), never a 12-row offset or an
+exact-date comparison. Report any
 coverage_note / missing_periods from the tool results in your findings.
 
 Return your findings as a structured block:

--- a/skills/factiq/SKILL.md
+++ b/skills/factiq/SKILL.md
@@ -595,8 +595,9 @@ which is also all it needs.
   `missing_periods` (a month the source never published, or one the query
   window cut off). Any period-over-period figure built with a fixed row
   offset (`LAG(value, 12)`, `shift(12)`, "the row 12 back") over those rows
-  is wrong from the first gap onward. Recompute by matching dates, name the
-  missing periods in the answer, and label partial aggregates as partial.
+  is wrong for the 12 rows after each gap (a forward offset: the 12 rows
+  before it). Recompute by matching dates, name the missing periods in the
+  answer, and label partial aggregates as partial.
 - **SQL timeout** — statements are capped at 30s. Filter on indexed columns
   (`series_id`, `dataset_code`) instead of scanning titles, and never
   pattern-match `series_id` on `data_points` — resolve ids from `series` first

--- a/tests/test_sql_docs.py
+++ b/tests/test_sql_docs.py
@@ -15,6 +15,7 @@ CHART_SPEC = (ROOT / "references/output/chart-spec.md").read_text(encoding="utf-
 REPORT_RULES = (ROOT / "references/report-patterns/README.md").read_text(
     encoding="utf-8"
 )
+JOIN = "date_trunc('month', prior.time) = date_trunc('month', cur.time) - interval '1 year'"
 YOY_TRAP = SQL_GUIDE.split("## Year-over-year on monthly data", 1)[1].split(
     "## HS trade datasets", 1
 )[0]
@@ -32,15 +33,21 @@ class PeriodAlignmentDocumentationTests(unittest.TestCase):
         conventions = SQL_GUIDE.split("## Always-true conventions", 1)[1].split(
             "\n## ", 1
         )[0]
-        self.assertIn("`data_points.time` is the period start", conventions)
-        self.assertIn("interval '1 year'", conventions)
+        self.assertIn(
+            "**Match periods on the calendar month, never on the exact date.**",
+            conventions,
+        )
+        self.assertIn(JOIN, conventions)
 
     def test_sql_guide_trap_shows_lag_as_bad_and_date_join_as_good(self):
         bad, good = YOY_TRAP.split("Good", 1)
         self.assertIn("Bad", bad)
         self.assertIn("LAG(value, 12) OVER (ORDER BY time)", bad)
-        self.assertIn("prior.time = cur.time - interval '1 year'", good)
+        self.assertIn(JOIN, good)
+        self.assertNotIn("prior.time = cur.time - interval", good)
+        self.assertIn("date_trunc('quarter', ...)", good)
         self.assertIn("generate_series(", good)
+        self.assertIn("ON date_trunc('month', d.time) = s.time", good)
         self.assertIn('transform="yoy_pct"', good)
         self.assertIn("series_math.py yoy", good)
 
@@ -70,6 +77,8 @@ class PeriodAlignmentDocumentationTests(unittest.TestCase):
             "\n5. ", 1
         )[0]
         self.assertIn("matched by date", compute_step)
+        self.assertIn(JOIN, compute_step)
+        self.assertIn("never compare exact", compute_step)
         self.assertIn("never `LAG(value, 12)`", compute_step)
         self.assertIn("`missing_periods`", compute_step)
         template = SKILL.split("You are a FactIQ research agent", 1)[1].split(

--- a/tests/test_sql_docs.py
+++ b/tests/test_sql_docs.py
@@ -1,0 +1,192 @@
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+SKILL = (ROOT / "skills/factiq/SKILL.md").read_text(encoding="utf-8")
+SQL_GUIDE = (ROOT / "references/data/sql-guide.md").read_text(encoding="utf-8")
+CHART_SPEC = (ROOT / "references/output/chart-spec.md").read_text(encoding="utf-8")
+REPORT_RULES = (ROOT / "references/report-patterns/README.md").read_text(
+    encoding="utf-8"
+)
+YOY_TRAP = SQL_GUIDE.split("## Year-over-year on monthly data", 1)[1].split(
+    "## HS trade datasets", 1
+)[0]
+
+
+def normalized(text: str) -> str:
+    return " ".join(text.lower().split())
+
+
+class PeriodAlignmentDocumentationTests(unittest.TestCase):
+    """A row offset is not a period offset once a month is missing; the docs
+    must steer every year-over-year calculation to a date match."""
+
+    def test_sql_guide_states_time_is_the_period_start(self):
+        conventions = SQL_GUIDE.split("## Always-true conventions", 1)[1].split(
+            "\n## ", 1
+        )[0]
+        self.assertIn("`data_points.time` is the period start", conventions)
+        self.assertIn("interval '1 year'", conventions)
+
+    def test_sql_guide_trap_shows_lag_as_bad_and_date_join_as_good(self):
+        bad, good = YOY_TRAP.split("Good", 1)
+        self.assertIn("Bad", bad)
+        self.assertIn("LAG(value, 12) OVER (ORDER BY time)", bad)
+        self.assertIn("prior.time = cur.time - interval '1 year'", good)
+        self.assertIn("generate_series(", good)
+        self.assertIn('transform="yoy_pct"', good)
+        self.assertIn("series_math.py yoy", good)
+
+    def test_sql_guide_trap_tells_the_model_to_disclose_gaps(self):
+        text = normalized(YOY_TRAP)
+        self.assertIn("coverage_note", text)
+        self.assertIn("missing_periods", text)
+        self.assertIn("partial", text)
+        self.assertIn("blank", text)
+
+    def test_sql_guide_pivot_says_a_missing_period_is_absent_not_null(self):
+        pivot = SQL_GUIDE.split("## Pivoting to wide format", 1)[1].split(
+            "\n## ", 1
+        )[0]
+        self.assertIn("absent from the pivot, not a null", pivot)
+
+    def test_skill_get_series_row_documents_transform(self):
+        row = next(line for line in SKILL.splitlines() if line.startswith("| `get_series`"))
+        self.assertIn("`transform?`", row)
+        self.assertIn('transform="yoy_pct"', row)
+        self.assertIn('"yoy_diff"', row)
+        self.assertIn("matched by calendar date", row)
+        self.assertIn("`coverage_note`", row)
+
+    def test_skill_workflow_and_subagent_template_forbid_row_offsets(self):
+        compute_step = SKILL.split("**Compute deterministically.**", 1)[1].split(
+            "\n5. ", 1
+        )[0]
+        self.assertIn("matched by date", compute_step)
+        self.assertIn("never `LAG(value, 12)`", compute_step)
+        self.assertIn("`missing_periods`", compute_step)
+        template = SKILL.split("You are a FactIQ research agent", 1)[1].split(
+            "FINDINGS:", 1
+        )[0]
+        self.assertIn("never a 12-row offset", template)
+        self.assertIn("coverage_note", template)
+
+    def test_skill_errors_section_explains_coverage_note(self):
+        errors = SKILL.split("## Errors and limits", 1)[1].split("\n## ", 1)[0]
+        self.assertIn("**`coverage_note` on a result**", errors)
+        self.assertIn("not an error", errors)
+        self.assertIn("matching dates", errors)
+
+    def test_report_rules_disclose_missing_periods(self):
+        rules = REPORT_RULES.split("## Rules the method implies", 1)[1]
+        self.assertIn("**A missing period is disclosed, not bridged.**", rules)
+        self.assertIn("`coverage_note`", rules)
+
+    def test_no_doc_endorses_a_row_offset_yoy(self):
+        # `shift(12)` / a bare LAG-by-12 may appear only inside the "Bad" example
+        # or in text that names it as the wrong pattern.
+        for name, text in (
+            ("SKILL.md", SKILL),
+            ("chart-spec.md", CHART_SPEC),
+            ("README.md", REPORT_RULES),
+        ):
+            with self.subTest(doc=name):
+                self.assertNotIn(".shift(12)", text)
+        self.assertNotIn("shift(12)", CHART_SPEC)
+        for match in re.finditer(r"LAG\(value, 12\)", SQL_GUIDE):
+            window = SQL_GUIDE[max(0, match.start() - 600) : match.start()]
+            self.assertTrue(
+                "Bad" in window or "spine" in window or "never" in window,
+                msg=SQL_GUIDE[match.start() - 120 : match.end() + 40],
+            )
+
+    def test_chart_spec_lineage_uses_a_date_matched_calculation(self):
+        calc = CHART_SPEC.split('"id": "calc"', 1)[1].split("}", 1)[0]
+        self.assertIn("series_math.py yoy", calc)
+        self.assertNotIn("12-month difference", calc)
+
+
+def monthly_payload(start_year: int, end_year: int, missing: str) -> dict:
+    rows = []
+    level = 100.0
+    for year in range(start_year, end_year + 1):
+        for month in range(1, 13):
+            time = f"{year}-{month:02d}-01"
+            level = round(level * 1.005, 4)
+            if time != missing:
+                rows.append([time, level])
+    return {"columns": ["time", "value"], "results": rows}
+
+
+def run_yoy(payload: dict, *extra: str) -> subprocess.CompletedProcess:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "series.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, str(SCRIPTS / "series_math.py"), "yoy", "--file", str(path), *extra],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+
+class SeriesMathYoyGapTests(unittest.TestCase):
+    """`yoy` matches on the calendar period, so a hole never shifts the
+    comparison, and the periods with no prior-year value are named on stderr."""
+
+    def parse(self, stdout: str) -> dict[str, str]:
+        lines = stdout.strip().splitlines()
+        self.assertEqual(lines[0].split("\t"), ["time", "value", "yoy_pct"])
+        return {parts[0]: parts[2] for parts in (line.split("\t") for line in lines[1:])}
+
+    def test_month_after_a_hole_still_compares_with_the_same_month_prior_year(self):
+        for missing in ("2025-10-01", "2025-03-01"):
+            with self.subTest(missing=missing):
+                payload = monthly_payload(2024, 2026, missing)
+                result = run_yoy(payload)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                yoy = self.parse(result.stdout)
+                # Every month after the hole must still be +6.17% on the
+                # compounding fixture (1.005**12 - 1), which is only true when
+                # the comparison is date-keyed; a 12-row offset gives 1.005**13.
+                after_hole = [
+                    time for time in yoy if time > missing and time < "2026-01-01"
+                ]
+                self.assertTrue(after_hole)
+                for time in after_hole:
+                    self.assertAlmostEqual(float(yoy[time]), 6.1678, places=3, msg=time)
+                # The month one year after the hole has no prior value.
+                year, rest = missing.split("-", 1)
+                blank = f"{int(year) + 1}-{rest}"
+                self.assertEqual(yoy[blank], "")
+                self.assertNotIn(missing, yoy)
+                self.assertIn("no prior-year observation for " + blank, result.stderr)
+                self.assertIn("say so in the answer", result.stderr)
+
+    def test_complete_series_prints_no_gap_note(self):
+        result = run_yoy(monthly_payload(2024, 2026, missing=""))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+        yoy = self.parse(result.stdout)
+        self.assertEqual(yoy["2024-06-01"], "")  # first year: no prior by design
+        self.assertNotEqual(yoy["2025-06-01"], "")
+
+    def test_gap_note_names_the_group_when_grouped(self):
+        payload = monthly_payload(2024, 2025, "2024-05-01")
+        payload["columns"] = ["series_id", "time", "value"]
+        payload["results"] = [["CPI", *row] for row in payload["results"]]
+        result = run_yoy(payload, "--group-col", "series_id")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("CPI: 2025-05-01", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Year-over-year changes are now defined everywhere in the plugin as the same period one year earlier, matched by calendar date, never by row position. The SQL guide, the skill workflow, the research-subagent template, the report rules, and the chart lineage example all carry the rule, and `series_math.py yoy` now tells the model which periods have no prior-year value. Plugin version is bumped to 0.31.0.

## The problem: a row offset is only a period offset when no period is missing

Monthly series can skip a month (a period the source never published, or one a query window cut off). A statement such as `LAG(value, 12) OVER (ORDER BY time)` then compares each month with the month thirteen periods back for the twelve rows after the gap (a forward offset such as `LEAD` gets the twelve rows before it wrong instead). Nothing errors and the numbers stay plausible, so the wrong figures reach the answer. The plugin docs did not warn about this, and the chart-spec lineage example showed `rate.shift(12)` as a normal calculation.

## The fix: guidance in every place a model decides how to compute YoY

- `references/data/sql-guide.md`: new section "Year-over-year on monthly data — never use LAG(value, 12)" with the bad pattern, a self-join on the calendar month (`date_trunc('month', prior.time) = date_trunc('month', cur.time) - interval '1 year'`), and a `generate_series` date-spine variant where LAG is correct. The join compares months, not exact dates, because the day stored inside `time` differs between sources (first of the period for most, last day of the quarter or fiscal year for some). Two supporting notes: match periods on `date_trunc('month', time)`, never on the exact date; a period with no row is absent from a pivot, not a null cell.
- `skills/factiq/SKILL.md`: the `get_series` row documents the server's new `transform` option (`yoy_pct` percent change, `yoy_diff` difference for rates), computed on the server by date with a null where the prior period is absent. The compute step says: one series → `get_series` with `transform`; several series or a merged table → `series_math.py yoy`; SQL → join on `date_trunc('month', time)`, never on the exact date. The subagent template carries the same rule. "Errors and limits" explains the `coverage_note` / `missing_periods` keys a result may carry and what to do with them (recompute by date, name the periods, label partial aggregates).
- `references/report-patterns/README.md`: new rule "A missing period is disclosed, not bridged."
- `references/output/chart-spec.md`: the lineage example computes YoY with `series_math.py yoy` instead of a 12-row shift.
- `scripts/series_math.py`: `yoy` already matched on the calendar period. It now prints a stderr note naming periods after the first year whose prior-year value is missing. Stdout is unchanged.

## Evidence

`python3 -m unittest discover tests` passes (68 tests, 12 new in `tests/test_sql_docs.py`). The new tests pin the documentation phrases, check that no document endorses `shift(12)` or a bare `LAG(value, 12)`, and run the script on a monthly series missing October 2025 (and, separately, March 2025).

### Before / after: `series_math.py yoy` on a monthly series missing 2025-10-01

Input: a compounding fixture (each month +0.5%) from 2024-01 to 2026-12 with no 2025-10-01 row.

Before, stdout for the months around the hole one year later:

```
2026-09-01	117.8908	6.1678
2026-10-01	118.4803	
2026-11-01	119.0727	6.1678
```

stderr: (empty)

After, stdout is identical, and stderr explains the blank:

```
note: no prior-year observation for 2026-10-01 — yoy_pct is blank there; say so in the answer rather than interpolating or comparing with a different period
```

With `--group-col series_id` the note names the group: `CPI: 2026-10-01`.

### Before / after: chart-spec lineage step

Before:

```json
"summary": "12-month difference on the monthly rate",
"code": "yoy = rate - rate.shift(12)", "code_language": "python"
```

After:

```json
"summary": "Same month one year earlier, matched by date, never a 12-row shift",
"code": "python3 series_math.py yoy --file rates.json --group-col series_id", "code_language": "bash"
```

## Details

- Server side of this change (the `transform` option on `get_series` and the `coverage_note` / `missing_periods` keys on `run_sql` and `get_series` results): defog-ai/worlddb#1517.
- Version bumped in `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

